### PR TITLE
Refactor telemetry duration fields to use float64 for milliseconds

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -421,6 +422,10 @@ func main() {
 	}
 	if investigator != nil {
 		dashOpts = append(dashOpts, dashboard.WithInvestigator(investigator))
+	}
+	// Pass a native kubernetes clientset for pod log fallback when telemetry backend is unavailable.
+	if k8sNative, err := kubernetes.NewForConfig(mgr.GetConfig()); err == nil {
+		dashOpts = append(dashOpts, dashboard.WithKubernetesClient(k8sNative))
 	}
 	dashboardServer := dashboard.NewServer(k8sClient, dashboardAddr, ctrl.Log, dashOpts...)
 	if err := mgr.Add(dashboardServer); err != nil {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -1,9 +1,11 @@
 package dashboard
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"net/http"
@@ -13,6 +15,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rcav1alpha1 "github.com/gaurangkudale/rca-operator/api/v1alpha1"
@@ -27,6 +32,7 @@ import (
 // It implements manager.Runnable so it can be registered with mgr.Add().
 type Server struct {
 	client       client.Client
+	k8sClient    kubernetes.Interface
 	addr         string
 	log          logr.Logger
 	querier      telemetry.TelemetryQuerier
@@ -51,6 +57,11 @@ func WithTopologyCache(c *topology.Cache) ServerOption {
 // WithInvestigator sets the AI investigator for the investigate API endpoint.
 func WithInvestigator(inv *rca.Investigator) ServerOption {
 	return func(s *Server) { s.investigator = inv }
+}
+
+// WithKubernetesClient sets the Kubernetes clientset for pod log fallback.
+func WithKubernetesClient(k kubernetes.Interface) ServerOption {
+	return func(s *Server) { s.k8sClient = k }
 }
 
 // NewServer returns a dashboard server that will listen on addr.
@@ -845,10 +856,18 @@ func (s *Server) handleServiceDetail(w http.ResponseWriter, r *http.Request) {
 			End:         end,
 			Limit:       limit,
 		})
-		if err != nil {
-			s.log.Error(err, "Failed to get logs", "service", serviceName)
-			http.Error(w, "failed to get logs", http.StatusInternalServerError)
-			return
+		if err != nil || len(logs) == 0 {
+			// Telemetry backend unavailable or returned nothing — fall back to k8s pod logs.
+			if s.k8sClient != nil {
+				podLogs, podErr := s.fetchPodLogs(r.Context(), serviceName, limit)
+				if podErr == nil && len(podLogs) > 0 {
+					writeJSON(w, podLogs)
+					return
+				}
+			}
+			if err != nil {
+				s.log.Error(err, "Failed to get logs", "service", serviceName)
+			}
 		}
 		if logs == nil {
 			logs = []telemetry.LogEntry{}
@@ -868,6 +887,104 @@ func (s *Server) handleServiceDetail(w http.ResponseWriter, r *http.Request) {
 		}
 		http.Error(w, "service not found", http.StatusNotFound)
 	}
+}
+
+// fetchPodLogs fetches recent log lines from Kubernetes pod logs as a fallback
+// when the telemetry backend (SigNoz/Loki) is unavailable.
+// It searches all namespaces for pods matching app=svc or app.kubernetes.io/name=svc.
+func (s *Server) fetchPodLogs(ctx context.Context, svc string, limit int) ([]telemetry.LogEntry, error) {
+	// List pods across all namespaces matching the service name.
+	podList, err := s.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		LabelSelector: "app=" + svc,
+		Limit:         5,
+	})
+	if err != nil || len(podList.Items) == 0 {
+		// Try alternative label
+		podList, err = s.k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=" + svc,
+			Limit:         5,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pods found for service %s", svc)
+	}
+
+	// Pick the most recently started running pod.
+	var targetPod *corev1.Pod
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if p.Status.Phase == corev1.PodRunning {
+			if targetPod == nil || p.CreationTimestamp.After(targetPod.CreationTimestamp.Time) {
+				targetPod = p
+			}
+		}
+	}
+	if targetPod == nil {
+		targetPod = &podList.Items[0]
+	}
+
+	tailLines := int64(limit)
+	req := s.k8sClient.CoreV1().Pods(targetPod.Namespace).GetLogs(targetPod.Name, &corev1.PodLogOptions{
+		TailLines:  &tailLines,
+		Timestamps: true,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pod log stream: %w", err)
+	}
+	defer stream.Close()
+
+	var entries []telemetry.LogEntry
+	scanner := bufio.NewScanner(io.LimitReader(stream, 2*1024*1024))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		entry := parsePodLogLine(line, svc)
+		entries = append(entries, entry)
+	}
+	return entries, scanner.Err()
+}
+
+// parsePodLogLine parses a pod log line (with optional RFC3339 timestamp prefix from --timestamps)
+// into a LogEntry. Severity is inferred from common keywords.
+func parsePodLogLine(line, svc string) telemetry.LogEntry {
+	entry := telemetry.LogEntry{
+		ServiceName: svc,
+		Severity:    "INFO",
+		Timestamp:   time.Now(),
+	}
+
+	// Strip leading RFC3339 timestamp added by --timestamps flag.
+	body := line
+	if len(line) > 30 {
+		ts, rest, ok := strings.Cut(line, " ")
+		if ok {
+			if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+				entry.Timestamp = t
+				body = rest
+			}
+		}
+	}
+	entry.Body = body
+
+	// Infer severity from common patterns (case-insensitive).
+	upper := strings.ToUpper(body)
+	switch {
+	case strings.Contains(upper, "FATAL") || strings.Contains(upper, "PANIC"):
+		entry.Severity = "FATAL"
+	case strings.Contains(upper, `"level":"error"`) || strings.Contains(upper, "ERROR") || strings.Contains(upper, `"level":"fatal"`):
+		entry.Severity = "ERROR"
+	case strings.Contains(upper, `"level":"warn"`) || strings.Contains(upper, "WARN") || strings.Contains(upper, "WARNING"):
+		entry.Severity = "WARN"
+	case strings.Contains(upper, `"level":"debug"`) || strings.Contains(upper, "DEBUG"):
+		entry.Severity = "DEBUG"
+	}
+	return entry
 }
 
 func (s *Server) handleInvestigate(w http.ResponseWriter, r *http.Request) {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -935,7 +935,7 @@ func (s *Server) fetchPodLogs(ctx context.Context, svc string, limit int) ([]tel
 	if err != nil {
 		return nil, fmt.Errorf("pod log stream: %w", err)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	var entries []telemetry.LogEntry
 	scanner := bufio.NewScanner(io.LimitReader(stream, 2*1024*1024))

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -1,1509 +1,1462 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>RCA Operator — Incident Management</title>
-<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
-<link rel="apple-touch-icon" sizes="192x192" href="/images/favicon-192x192.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<style>
-/* ── Theme Variables ─────────────────────────────── */
-:root {
-  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
-  --transition: 0.15s ease;
-}
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RCA Operator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: 'Inter', system-ui, sans-serif; background: #020817; color: #cbd5e1; }
+        .font-mono { font-family: 'JetBrains Mono', monospace; }
 
-[data-theme="dark"] {
-  --bg: #0f1117;
-  --bg-raised: #161822;
-  --bg-card: #1c1f2e;
-  --bg-hover: #242738;
-  --bg-selected: #2a2d42;
-  --bg-input: #1c1f2e;
-  --border: rgba(255,255,255,0.08);
-  --border-strong: rgba(255,255,255,0.14);
-  --text-primary: #e8eaed;
-  --text-secondary: #9aa0b0;
-  --text-tertiary: #5c6175;
-  --accent: #6c8cff;
-  --accent-soft: rgba(108,140,255,0.12);
-  --red: #ff6b6b;
-  --red-soft: rgba(255,107,107,0.12);
-  --amber: #fbbf24;
-  --amber-soft: rgba(251,191,36,0.12);
-  --green: #34d399;
-  --green-soft: rgba(52,211,153,0.12);
-  --purple: #a78bfa;
-  --purple-soft: rgba(167,139,250,0.12);
-  --blue: #60a5fa;
-  --blue-soft: rgba(96,165,250,0.12);
-  --scrollbar: #2a2d42;
-}
+        /* Scrollbars */
+        ::-webkit-scrollbar { width: 5px; height: 5px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb { background: #1e293b; border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: #334155; }
 
-[data-theme="light"] {
-  --bg: #f5f6f8;
-  --bg-raised: #ffffff;
-  --bg-card: #ffffff;
-  --bg-hover: #f0f1f4;
-  --bg-selected: #e8eaff;
-  --bg-input: #f0f1f4;
-  --border: rgba(0,0,0,0.08);
-  --border-strong: rgba(0,0,0,0.14);
-  --text-primary: #1a1c24;
-  --text-secondary: #5c6175;
-  --text-tertiary: #9aa0b0;
-  --accent: #4f6ef7;
-  --accent-soft: rgba(79,110,247,0.08);
-  --red: #ef4444;
-  --red-soft: rgba(239,68,68,0.08);
-  --amber: #d97706;
-  --amber-soft: rgba(217,119,6,0.08);
-  --green: #059669;
-  --green-soft: rgba(5,150,105,0.08);
-  --purple: #7c3aed;
-  --purple-soft: rgba(124,58,237,0.08);
-  --blue: #2563eb;
-  --blue-soft: rgba(37,99,235,0.08);
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
-  --shadow-md: 0 4px 16px rgba(0,0,0,0.1);
-  --scrollbar: #d1d5db;
-}
+        /* Canvas grid */
+        .canvas-bg {
+            background-color: #020817;
+            background-image: linear-gradient(rgba(51,65,85,0.08) 1px, transparent 1px),
+                              linear-gradient(90deg, rgba(51,65,85,0.08) 1px, transparent 1px);
+            background-size: 32px 32px;
+        }
 
-/* ── Base Reset ──────────────────────────────────── */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-body {
-  font-family: var(--font-sans);
-  color: var(--text-primary);
-  background: var(--bg);
-  overflow-x: hidden;
-  -webkit-font-smoothing: antialiased;
-}
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 3px; }
-button {
-  cursor: pointer; font-family: inherit; border: none; background: none;
-  color: inherit; outline: none; -webkit-appearance: none; appearance: none;
-}
-button:focus, button:focus-visible { outline: none; }
-select { font-family: inherit; }
+        /* SVG edges */
+        .edge-path { stroke: #1e293b; stroke-width: 2; fill: none; transition: stroke 0.3s; }
+        .edge-path.healthy { stroke: #10b981; }
+        .edge-path.warning { stroke: #f59e0b; stroke-dasharray: 5 4; animation: flow 2s linear infinite; }
+        .edge-path.critical { stroke: #ef4444; stroke-width: 2.5; stroke-dasharray: 7 5; animation: flow 1s linear infinite; }
+        .edge-path.active { stroke: #10b981; }
+        @keyframes flow { to { stroke-dashoffset: -18; } }
 
-@keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
-@keyframes pulse { 0% { transform: scale(1); opacity: 0.6; } 100% { transform: scale(2.4); opacity: 0; } }
-@keyframes blink { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-@keyframes slideIn { from { opacity: 0; transform: translateX(12px); } to { opacity: 1; transform: translateX(0); } }
+        /* Topology nodes */
+        .topo-node { position: absolute; transform: translate(-50%, -50%); cursor: grab; user-select: none; z-index: 10; }
+        .topo-node:active { cursor: grabbing; }
+        .topo-node.selected .node-ring { border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,0.25); }
 
-/* ── Layout ──────────────────────────────────────── */
-.app { display: flex; flex-direction: column; min-height: 100vh; }
+        /* Sparkline bars */
+        .spark-bar { border-radius: 2px 2px 0 0; transition: height 0.3s; min-height: 3px; }
 
-/* ── Header ──────────────────────────────────────── */
-.header {
-  height: 56px; display: flex; align-items: center; justify-content: space-between;
-  padding: 0 20px; background: var(--bg-raised); border-bottom: 1px solid var(--border);
-  flex-shrink: 0; gap: 16px;
-}
-.header-left { display: flex; align-items: center; gap: 14px; }
-.logo {
-  display: flex; align-items: center; gap: 8px;
-  font-size: 15px; font-weight: 700; letter-spacing: -0.3px; color: var(--text-primary);
-}
-.logo-img { height: 32px; width: auto; display: block; }
-.version { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); }
+        /* Slide panels */
+        .slide-right { transition: transform 0.25s cubic-bezier(0.4,0,0.2,1); }
+        .open { transform: translateX(0); }
+        .closed { transform: translateX(100%); }
 
-.nav { display: flex; gap: 4px; }
-.nav-item {
-  padding: 7px 16px; border-radius: var(--radius-sm); font-size: 13px; font-weight: 500;
-  color: var(--text-secondary); cursor: pointer; transition: all var(--transition);
-  user-select: none;
-}
-.nav-item:hover { background: var(--bg-hover); color: var(--text-primary); }
-.nav-item.active { background: var(--accent-soft); color: var(--accent); }
-.nav-item.active:hover { background: var(--accent-soft); }
+        /* Nav */
+        .nav-item { border-left: 2px solid transparent; transition: all 0.15s; }
+        .nav-item.active { border-left-color: #6366f1; background: rgba(99,102,241,0.1); color: #a5b4fc; }
+        .nav-item:not(.active):hover { background: rgba(255,255,255,0.04); }
 
-.header-right { display: flex; align-items: center; gap: 10px; }
-.header-pill {
-  display: flex; align-items: center; gap: 5px; padding: 4px 10px; border-radius: 20px;
-  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
-}
-.pill-active { background: var(--red-soft); color: var(--red); }
-.pill-p1 { background: var(--red-soft); color: var(--red); }
+        /* Incident row */
+        .inc-row { border-left: 2px solid transparent; transition: all 0.15s; }
+        .inc-row.sel { border-left-color: #6366f1; background: rgba(99,102,241,0.07); }
+        .inc-row:hover:not(.sel) { background: rgba(255,255,255,0.03); }
 
-.theme-toggle {
-  width: 34px; height: 34px; border-radius: var(--radius-sm); border: 1px solid var(--border) !important;
-  background: var(--bg-input) !important; color: var(--text-secondary); display: flex; align-items: center;
-  justify-content: center; font-size: 16px; transition: all var(--transition);
-}
-.theme-toggle:hover { background: var(--bg-hover) !important; color: var(--text-primary); border-color: var(--border-strong) !important; }
-.theme-toggle:focus, .theme-toggle:focus-visible { outline: none; }
+        /* Log line */
+        .log-line { font-family: 'JetBrains Mono', monospace; font-size: 11px; line-height: 1.6; padding: 1px 0; border-bottom: 1px solid rgba(30,41,59,0.4); }
+        .log-line.FATAL, .log-line.ERROR { background: rgba(239,68,68,0.06); }
+        .log-line.WARN { background: rgba(245,158,11,0.04); }
 
-.tz-select {
-  font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary);
-  background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  padding: 5px 24px 5px 8px; outline: none; appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%239aa0b0'/%3E%3C/svg%3E");
-  background-repeat: no-repeat; background-position: right 6px center;
-  max-width: 180px;
-}
-.tz-select option { background: var(--bg-card); color: var(--text-primary); }
+        /* Metric bar chart */
+        .metric-bar-wrap { display: flex; align-items: flex-end; gap: 3px; height: 64px; }
+        .metric-bar { flex: 1; border-radius: 2px 2px 0 0; transition: height 0.3s; }
 
-.clock {
-  font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary);
-  min-width: 90px; text-align: right; font-variant-numeric: tabular-nums;
-}
+        /* Trace row */
+        .trace-row { transition: background 0.1s; }
+        .trace-row:hover { background: rgba(255,255,255,0.03); }
 
-/* ── Main Body ───────────────────────────────────── */
-.main { display: flex; flex: 1; overflow: hidden; }
+        /* Pulse dot */
+        @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.5} }
+        .pulse-dot { animation: pulse 1.5s ease-in-out infinite; }
 
-/* ── Sidebar ─────────────────────────────────────── */
-.sidebar {
-  width: 220px; flex-shrink: 0; background: var(--bg-raised); border-right: 1px solid var(--border);
-  overflow-y: auto; padding: 16px 0; display: flex; flex-direction: column; gap: 24px;
-}
-.sidebar-section { padding: 0 12px; }
-.sidebar-title {
-  font-size: 10px; font-weight: 600; letter-spacing: 1.2px; text-transform: uppercase;
-  color: var(--text-tertiary); margin-bottom: 8px; padding: 0 8px;
-}
+        /* Toast */
+        #toast { transition: bottom 0.3s cubic-bezier(0.4,0,0.2,1), opacity 0.3s; }
 
-/* Metric cards */
-.metric-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-.metric-card {
-  padding: 10px 10px; border-radius: var(--radius-md); background: var(--bg-card);
-  border: 1px solid var(--border); text-align: center;
-}
-.metric-card-value { font-family: var(--font-mono); font-size: 22px; font-weight: 600; line-height: 1.2; }
-.metric-card-label { font-size: 9px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; color: var(--text-tertiary); margin-top: 2px; }
-
-/* Sidebar items */
-.sb-item {
-  display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: var(--radius-sm);
-  cursor: pointer; transition: all var(--transition); font-size: 12px; color: var(--text-secondary);
-}
-.sb-item:hover { background: var(--bg-hover); color: var(--text-primary); }
-.sb-item.active { background: var(--accent-soft); color: var(--accent); font-weight: 500; }
-.sb-badge {
-  margin-left: auto; font-family: var(--font-mono); font-size: 10px; font-weight: 600;
-  padding: 1px 6px; border-radius: 10px; background: var(--red-soft); color: var(--red);
-}
-.sb-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-
-/* Agent items */
-.agent-item {
-  display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: var(--radius-sm);
-  font-size: 12px;
-}
-.agent-item .status-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-.agent-item .name { color: var(--text-primary); font-weight: 500; }
-.agent-item .label { font-size: 10px; color: var(--text-tertiary); margin-left: auto; font-family: var(--font-mono); }
-.agent-sub { font-size: 10px; color: var(--text-tertiary); padding: 0 8px 0 22px; }
-
-/* ── Content Area ────────────────────────────────── */
-.content { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-
-/* Toolbar */
-.toolbar {
-  display: flex; align-items: center; gap: 10px; padding: 10px 16px;
-  background: var(--bg-raised); border-bottom: 1px solid var(--border); flex-shrink: 0;
-}
-.filter-group { display: flex; align-items: center; gap: 6px; }
-.filter-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.5px; }
-.filter-select {
-  font-family: var(--font-mono); font-size: 11px; color: var(--text-primary);
-  background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  padding: 5px 24px 5px 8px; outline: none; appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%239aa0b0'/%3E%3C/svg%3E");
-  background-repeat: no-repeat; background-position: right 6px center;
-}
-.filter-select option { background: var(--bg-card); color: var(--text-primary); }
-.toolbar-spacer { flex: 1; }
-.toolbar-meta { font-size: 11px; color: var(--text-tertiary); }
-.toolbar-kbd { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); }
-
-/* Split view */
-.split { flex: 1; display: flex; overflow: hidden; }
-.list-pane { overflow-y: auto; }
-.list-pane.full { width: 100%; }
-.list-pane.compact { width: 320px; flex-shrink: 0; border-right: 1px solid var(--border); }
-
-/* ── Table Headers ───────────────────────────────── */
-.list-header {
-  display: flex; align-items: center; gap: 12px; padding: 8px 16px;
-  background: var(--bg-raised); border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 2;
-}
-.list-header span {
-  font-size: 10px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-
-/* ── Incident Row ────────────────────────────────── */
-.inc-row {
-  display: flex; align-items: center; gap: 12px; padding: 12px 16px;
-  border-bottom: 1px solid var(--border); cursor: pointer; transition: background var(--transition);
-}
-.inc-row:hover { background: var(--bg-hover); }
-.inc-row.selected { background: var(--bg-selected); }
-.inc-row.compact { padding: 10px 12px; gap: 10px; }
-.inc-row.resolved { opacity: 0.6; }
-
-.inc-num { font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary); min-width: 22px; text-align: right; }
-
-/* Severity badge */
-.sev {
-  display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-sm);
-  font-family: var(--font-mono); font-weight: 700; letter-spacing: 0.3px; flex-shrink: 0;
-}
-.sev.md { width: 36px; height: 24px; font-size: 11px; }
-.sev.sm { width: 30px; height: 20px; font-size: 10px; }
-.sev-P1 { background: var(--red-soft); color: var(--red); }
-.sev-P2 { background: var(--amber-soft); color: var(--amber); }
-.sev-P3 { background: var(--blue-soft); color: var(--blue); }
-.sev-P4 { background: var(--bg-hover); color: var(--text-tertiary); }
-
-/* Phase badge */
-.phase {
-  display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 20px;
-  font-size: 11px; font-weight: 600; white-space: nowrap;
-}
-.phase-Active { background: var(--red-soft); color: var(--red); }
-.phase-Detecting { background: var(--purple-soft); color: var(--purple); }
-.phase-Resolved { background: var(--green-soft); color: var(--green); }
-
-.inc-info { flex: 1; min-width: 0; }
-.inc-name { font-size: 13px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.inc-name.compact { font-size: 12px; }
-.inc-meta { font-size: 11px; color: var(--text-tertiary); margin-top: 1px; }
-.inc-ns { font-size: 11px; color: var(--text-secondary); background: var(--bg-hover); padding: 2px 8px; border-radius: var(--radius-sm); flex-shrink: 0; }
-.inc-time { text-align: right; flex-shrink: 0; }
-.inc-time-rel { font-family: var(--font-mono); font-size: 11px; color: var(--text-secondary); }
-.inc-time-abs { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); }
-
-/* ── Detail Panel ────────────────────────────────── */
-.detail {
-  flex: 1; overflow-y: auto; background: var(--bg); animation: slideIn 0.15s ease-out;
-}
-.detail-head {
-  padding: 16px 20px; background: var(--bg-raised); border-bottom: 1px solid var(--border);
-  position: sticky; top: 0; z-index: 2;
-}
-.detail-badges { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
-.detail-title { font-size: 20px; font-weight: 700; color: var(--text-primary); letter-spacing: -0.3px; }
-.detail-subtitle { font-size: 12px; color: var(--text-tertiary); margin-top: 4px; }
-.detail-subtitle .sep { margin: 0 6px; }
-.detail-subtitle .val { color: var(--text-secondary); }
-.detail-dur { margin-top: 8px; display: flex; align-items: baseline; gap: 8px; }
-.detail-dur-label { font-size: 10px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; color: var(--text-tertiary); }
-.detail-dur-val { font-family: var(--font-mono); font-size: 16px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.detail-id { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); margin-top: 8px; }
-.detail-close {
-  position: absolute; top: 16px; right: 16px; width: 32px; height: 32px; border-radius: var(--radius-sm);
-  border: 1px solid var(--border) !important; background: var(--bg-input) !important; color: var(--text-secondary);
-  font-size: 18px; display: flex; align-items: center; justify-content: center; transition: all var(--transition);
-}
-.detail-close:hover { background: var(--bg-hover) !important; color: var(--text-primary); }
-
-.detail-body { padding: 20px; display: flex; flex-direction: column; gap: 24px; }
-
-/* Tag */
-.tag {
-  display: inline-flex; align-items: center; padding: 3px 8px; border-radius: var(--radius-sm);
-  font-size: 11px; font-weight: 500;
-}
-.tag-default { background: var(--bg-hover); color: var(--text-secondary); }
-.tag-green { background: var(--green-soft); color: var(--green); }
-.tag-purple { background: var(--purple-soft); color: var(--purple); }
-
-/* Section */
-.section-title {
-  font-size: 11px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase;
-  color: var(--text-tertiary); margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid var(--border);
-}
-.section-title-toggle {
-  font-size: 11px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase;
-  color: var(--text-tertiary); margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; justify-content: space-between; cursor: pointer; user-select: none;
-}
-.section-title-toggle:hover { color: var(--text-secondary); }
-.toggle-icon { font-size: 12px; transition: transform var(--transition); }
-.toggle-icon.collapsed { transform: rotate(-90deg); }
-
-/* Timeline */
-.timeline { position: relative; overflow-x: auto; padding: 20px 0 8px; }
-.tl-track { display: flex; gap: 0; position: relative; padding-top: 16px; min-width: min-content; }
-.tl-line { position: absolute; top: 20px; left: 16px; right: 16px; height: 2px; background: var(--border-strong); border-radius: 1px; }
-.tl-entry { position: relative; flex: 0 0 auto; min-width: 200px; max-width: 260px; padding: 0 14px 8px; }
-.tl-dot {
-  position: absolute; top: -12px; left: 14px; width: 10px; height: 10px; border-radius: 50%;
-  background: var(--bg-hover); border: 2px solid var(--border-strong);
-}
-.tl-dot.first { background: var(--accent); border-color: var(--accent); }
-.tl-dot.last-resolved { background: var(--green); border-color: var(--green); }
-.tl-time { font-family: var(--font-mono); font-size: 11px; color: var(--accent); margin-top: 8px; }
-.tl-time .rel { color: var(--text-tertiary); margin-left: 6px; font-size: 10px; }
-.tl-event { font-size: 12px; color: var(--text-primary); line-height: 1.6; margin-top: 4px; }
-
-/* Cards */
-.card {
-  padding: 10px 12px; border-radius: var(--radius-md); background: var(--bg-card);
-  border: 1px solid var(--border); display: flex; align-items: center; gap: 10px;
-}
-.card + .card { margin-top: 6px; }
-
-/* Signal cards */
-.signal-num { font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary); min-width: 16px; }
-.signal-dot { width: 6px; height: 6px; border-radius: 2px; flex-shrink: 0; }
-.signal-text { font-size: 12px; color: var(--text-primary); line-height: 1.5; flex: 1; }
-.signal-count {
-  font-family: var(--font-mono); font-size: 10px; font-weight: 600; padding: 1px 6px;
-  border-radius: 10px; background: var(--accent-soft); color: var(--accent); flex-shrink: 0;
-}
-
-/* Resource cards */
-.res-kind {
-  font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.5px;
-  padding: 3px 8px; border-radius: var(--radius-sm); min-width: 70px; text-align: center;
-  background: var(--accent-soft); color: var(--accent); flex-shrink: 0;
-}
-.res-name { font-size: 12px; font-weight: 500; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.res-ns { font-size: 11px; color: var(--text-tertiary); }
-
-/* Cmd rows */
-.cmd-num { font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary); min-width: 16px; }
-.cmd-code { flex: 1; font-family: var(--font-mono); font-size: 11px; color: var(--accent); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmd-code.muted { color: var(--text-secondary); }
-
-/* Copy btn */
-.copy-btn {
-  flex-shrink: 0; border: 1px solid var(--border) !important; border-radius: var(--radius-sm);
-  padding: 3px 10px; font-family: var(--font-mono); font-size: 10px; font-weight: 500;
-  background: var(--bg-input) !important; color: var(--text-tertiary); transition: all var(--transition);
-}
-.copy-btn:hover { border-color: var(--border-strong) !important; color: var(--text-secondary); }
-.copy-btn.ok { background: var(--green-soft) !important; color: var(--green); border-color: transparent !important; }
-
-/* Notification rows */
-.notif-ch { font-size: 12px; font-weight: 500; color: var(--text-primary); min-width: 80px; }
-.notif-dest { font-size: 11px; color: var(--text-tertiary); }
-.notif-status { font-family: var(--font-mono); font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; }
-.notif-ok { background: var(--green-soft); color: var(--green); }
-.notif-skip { color: var(--text-tertiary); }
-
-/* Conditions */
-.cond-type { font-size: 12px; font-weight: 600; color: var(--text-primary); min-width: 80px; }
-.cond-badge { font-family: var(--font-mono); font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; }
-.cond-true { background: var(--green-soft); color: var(--green); }
-.cond-unknown { background: var(--purple-soft); color: var(--purple); }
-.cond-false { background: var(--bg-hover); color: var(--text-tertiary); }
-.cond-reason { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); }
-.cond-msg { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
-
-/* Evidence stub */
-.evidence-card {
-  padding: 16px; border-radius: var(--radius-md); border: 1px dashed var(--border);
-  background: var(--purple-soft);
-}
-.evidence-label { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
-.evidence-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--purple); }
-.evidence-tag { font-size: 10px; font-weight: 600; letter-spacing: 1px; color: var(--purple); text-transform: uppercase; }
-.evidence-body { font-size: 12px; color: var(--text-secondary); line-height: 1.7; }
-
-/* ── Status Bar ──────────────────────────────────── */
-.status-bar {
-  height: 28px; display: flex; align-items: center; gap: 12px; padding: 0 16px;
-  background: var(--bg-raised); border-top: 1px solid var(--border); flex-shrink: 0;
-}
-.status-bar span { font-size: 10px; color: var(--text-tertiary); }
-.status-sep { width: 1px; height: 12px; background: var(--border); }
-
-/* ── Empty State ─────────────────────────────────── */
-.empty-state {
-  padding: 60px 20px; text-align: center;
-}
-.empty-state-title { font-size: 14px; color: var(--text-secondary); margin-bottom: 4px; }
-.empty-state-sub { font-size: 12px; color: var(--text-tertiary); }
-
-/* ── Pulse indicator ─────────────────────────────── */
-.pulse-dot {
-  position: relative; display: inline-flex; width: 8px; height: 8px; flex-shrink: 0;
-}
-.pulse-dot .ring {
-  position: absolute; inset: 0; border-radius: 50%; opacity: 0.35;
-  animation: pulse 1.8s ease-out infinite;
-}
-.pulse-dot .dot {
-  position: absolute; inset: 0; border-radius: 50%;
-  animation: blink 2s ease-in-out infinite;
-}
-
-/* ── Rules/Agents/Namespaces tables ──────────────── */
-.data-table { width: 100%; }
-.data-row {
-  display: flex; align-items: center; gap: 12px; padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
-}
-.data-row:hover { background: var(--bg-hover); }
-
-/* ── Topology View ──────────────────────────────── */
-.topo-container { flex: 1; display: flex; overflow: hidden; position: relative; }
-.topo-svg { flex: 1; cursor: grab; }
-.topo-svg:active { cursor: grabbing; }
-.topo-svg .node-group { cursor: pointer; }
-.topo-svg .node-circle { stroke-width: 2; transition: filter 0.15s; }
-.topo-svg .node-group:hover .node-circle { filter: brightness(1.2); }
-.topo-svg .node-label { font-family: var(--font-sans); font-size: 11px; font-weight: 600; fill: var(--text-primary); pointer-events: none; }
-.topo-svg .node-sublabel { font-family: var(--font-mono); font-size: 9px; fill: var(--text-tertiary); pointer-events: none; }
-.topo-svg .node-icon { font-size: 14px; pointer-events: none; }
-.topo-svg .edge-line { stroke-width: 1.5; fill: none; }
-.topo-svg .edge-line.status-active { stroke: var(--border-strong); }
-.topo-svg .edge-line.status-warning { stroke: var(--amber); stroke-dasharray: 6 3; }
-.topo-svg .edge-line.status-critical { stroke: var(--red); stroke-dasharray: 4 2; }
-.topo-svg .edge-label { font-family: var(--font-mono); font-size: 9px; fill: var(--text-tertiary); }
-
-.topo-side { width: 320px; flex-shrink: 0; border-left: 1px solid var(--border); background: var(--bg-raised); overflow-y: auto; animation: slideIn 0.15s ease-out; }
-.topo-side-head { padding: 16px; border-bottom: 1px solid var(--border); }
-.topo-side-title { font-size: 16px; font-weight: 700; color: var(--text-primary); }
-.topo-side-subtitle { font-size: 11px; color: var(--text-tertiary); margin-top: 4px; }
-.topo-side-body { padding: 16px; display: flex; flex-direction: column; gap: 16px; }
-.topo-side-close { position: absolute; top: 12px; right: 12px; width: 28px; height: 28px; border-radius: var(--radius-sm); border: 1px solid var(--border) !important; background: var(--bg-input) !important; color: var(--text-secondary); display: flex; align-items: center; justify-content: center; font-size: 16px; }
-.topo-side-close:hover { background: var(--bg-hover) !important; color: var(--text-primary); }
-
-.topo-metric { display: flex; align-items: baseline; gap: 8px; padding: 6px 0; }
-.topo-metric-label { font-size: 10px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; color: var(--text-tertiary); min-width: 80px; }
-.topo-metric-val { font-family: var(--font-mono); font-size: 14px; font-weight: 600; }
-
-.topo-blast-tag { display: inline-block; padding: 3px 8px; border-radius: var(--radius-sm); font-size: 11px; font-weight: 500; background: var(--red-soft); color: var(--red); margin: 2px; }
-
-.topo-legend { position: absolute; bottom: 12px; left: 12px; background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 10px 14px; display: flex; gap: 16px; font-size: 10px; color: var(--text-tertiary); }
-.topo-legend-item { display: flex; align-items: center; gap: 5px; }
-.topo-legend-dot { width: 8px; height: 8px; border-radius: 50%; }
-
-.topo-controls { position: absolute; top: 12px; right: 12px; display: flex; gap: 4px; }
-.topo-btn { width: 32px; height: 32px; border-radius: var(--radius-sm); border: 1px solid var(--border) !important; background: var(--bg-card) !important; color: var(--text-secondary); display: flex; align-items: center; justify-content: center; font-size: 16px; }
-.topo-btn:hover { background: var(--bg-hover) !important; color: var(--text-primary); }
-
-@media (max-width: 980px) {
-  .sidebar { display: none; }
-  .header { flex-wrap: wrap; height: auto; padding: 10px 16px; }
-  .nav { order: 3; width: 100%; }
-  .topo-side { width: 260px; }
-}
-</style>
+        /* Timeline connector line */
+        .tl-line { position: absolute; top: 28px; left: 0; right: 0; height: 1px; background: #1e293b; z-index: 0; }
+    </style>
 </head>
-<body>
-<div class="app">
-  <!-- Header -->
-  <header class="header">
-    <div class="header-left">
-      <div id="conn-dot"></div>
-      <div class="logo">
-        <img src="/images/logo.png" alt="RCA Operator" class="logo-img">
-      </div>
-      <span class="version">v0.0.16</span>
-      <nav class="nav" id="nav">
-        <div class="nav-item active" data-tab="incidents" onclick="window._tab('incidents')">Incidents</div>
-        <div class="nav-item" data-tab="topology" onclick="window._tab('topology')">Topology</div>
-        <div class="nav-item" data-tab="rules" onclick="window._tab('rules')">Rules</div>
-        <div class="nav-item" data-tab="agents" onclick="window._tab('agents')">Agents</div>
-        <div class="nav-item" data-tab="namespaces" onclick="window._tab('namespaces')">Namespaces</div>
-      </nav>
-    </div>
-    <div class="header-right" id="header-right"></div>
-  </header>
+<body class="flex h-screen overflow-hidden">
 
-  <div class="main">
-    <!-- Sidebar -->
-    <aside class="sidebar">
-      <div class="sidebar-section">
-        <div class="sidebar-title">Overview</div>
-        <div class="metric-grid" id="sb-metrics"></div>
-      </div>
-      <div class="sidebar-section">
-        <div class="sidebar-title">Namespaces</div>
-        <div id="sb-ns"></div>
-      </div>
-      <div class="sidebar-section">
-        <div class="sidebar-title">Severity</div>
-        <div id="sb-sev"></div>
-      </div>
-      <div class="sidebar-section">
-        <div class="sidebar-title">Agents</div>
-        <div id="sb-agents"></div>
-      </div>
-      <div class="sidebar-section">
-        <div class="sidebar-title">Rule Engine</div>
-        <div id="sb-rules"></div>
-      </div>
-    </aside>
-
-    <!-- Content -->
-    <div class="content">
-      <div class="toolbar" id="toolbar"></div>
-      <div class="split">
-        <div class="list-pane full" id="list-pane"></div>
-        <div class="detail" id="detail-panel" style="display:none"></div>
-      </div>
-      <div class="status-bar" id="status-bar"></div>
+<!-- ─── Sidebar ─────────────────────────────────────────────────────────── -->
+<aside class="w-14 bg-[#0a1628] border-r border-slate-800/60 flex flex-col items-center py-3 gap-1 shrink-0 z-50">
+    <div class="w-9 h-9 bg-indigo-600 rounded-xl flex items-center justify-center shadow-lg shadow-indigo-900/40 mb-3 cursor-pointer" onclick="showToast('RCA Operator — connected')">
+        <i data-lucide="radar" class="w-5 h-5 text-white"></i>
     </div>
-  </div>
+
+    <button id="nav-topology" onclick="switchTab('topology')" class="nav-item active w-full flex justify-center py-3 text-slate-400 relative group">
+        <i data-lucide="network" class="w-4.5 h-4.5"></i>
+        <span class="tooltip">Topology</span>
+    </button>
+    <button id="nav-incidents" onclick="switchTab('incidents')" class="nav-item w-full flex justify-center py-3 text-slate-500 relative group">
+        <i data-lucide="alert-triangle" class="w-4.5 h-4.5"></i>
+        <div id="inc-badge" class="absolute top-2 right-2.5 w-1.5 h-1.5 bg-red-500 rounded-full pulse-dot hidden"></div>
+        <span class="tooltip">Incidents</span>
+    </button>
+    <button id="nav-metrics" onclick="switchTab('metrics')" class="nav-item w-full flex justify-center py-3 text-slate-500 relative group">
+        <i data-lucide="activity" class="w-4.5 h-4.5"></i>
+        <span class="tooltip">Metrics</span>
+    </button>
+    <button id="nav-logs" onclick="switchTab('logs')" class="nav-item w-full flex justify-center py-3 text-slate-500 relative group">
+        <i data-lucide="terminal" class="w-4.5 h-4.5"></i>
+        <span class="tooltip">Logs</span>
+    </button>
+    <button id="nav-traces" onclick="switchTab('traces')" class="nav-item w-full flex justify-center py-3 text-slate-500 relative group">
+        <i data-lucide="git-branch" class="w-4.5 h-4.5"></i>
+        <span class="tooltip">Traces</span>
+    </button>
+
+    <div class="w-6 h-px bg-slate-800 my-1"></div>
+
+    <button id="nav-rules" onclick="switchTab('rules')" class="nav-item w-full flex justify-center py-3 text-slate-500 relative group">
+        <i data-lucide="file-code-2" class="w-4.5 h-4.5"></i>
+        <span class="tooltip">RCA Rules</span>
+    </button>
+    <button id="nav-agents" onclick="switchTab('agents')" class="nav-item w-full flex justify-center py-3 text-slate-500 relative group">
+        <i data-lucide="cpu" class="w-4.5 h-4.5"></i>
+        <span class="tooltip">RCA Agents</span>
+    </button>
+
+    <div class="mt-auto">
+        <button onclick="showToast('Settings panel coming soon')" class="w-full flex justify-center py-3 text-slate-600 hover:text-slate-400 transition-colors">
+            <i data-lucide="settings" class="w-4.5 h-4.5"></i>
+        </button>
+    </div>
+</aside>
+
+<style>
+.tooltip { position: absolute; left: calc(100% + 8px); top: 50%; transform: translateY(-50%); background: #1e293b; color: #e2e8f0; font-size: 11px; font-weight: 500; padding: 4px 8px; border-radius: 6px; white-space: nowrap; opacity: 0; pointer-events: none; transition: opacity 0.15s; z-index: 100; border: 1px solid #334155; }
+.group:hover .tooltip { opacity: 1; }
+</style>
+
+<!-- ─── Main ──────────────────────────────────────────────────────────────── -->
+<main class="flex-grow flex flex-col relative min-w-0 h-full overflow-hidden">
+
+    <!-- Header -->
+    <header class="h-12 bg-[#0a1628]/95 backdrop-blur border-b border-slate-800/60 flex items-center justify-between px-5 shrink-0 z-40">
+        <div class="flex items-center gap-3">
+            <div class="flex items-center gap-1.5 text-xs font-medium">
+                <span id="hdr-cluster" class="text-slate-400 hover:text-slate-200 cursor-pointer transition-colors">prod-cluster-01</span>
+                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-600"></i>
+                <span id="hdr-ns" class="text-slate-200 cursor-pointer">—</span>
+            </div>
+            <div class="w-px h-4 bg-slate-700/60"></div>
+            <button id="active-pill" onclick="switchTab('incidents')" class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-bold tracking-wide border transition-colors cursor-pointer">
+                <span id="pill-dot" class="w-1.5 h-1.5 rounded-full pulse-dot"></span>
+                <span id="pill-text">—</span>
+            </button>
+        </div>
+        <div class="flex items-center gap-5 text-[11px] font-mono text-slate-400">
+            <span class="hidden sm:flex items-center gap-1.5"><i data-lucide="server" class="w-3 h-3 text-emerald-400"></i><span id="hdr-svc">0 Services</span></span>
+            <span class="hidden sm:flex items-center gap-1.5"><i data-lucide="cpu" class="w-3 h-3 text-indigo-400"></i><span id="hdr-agt">0 Agents</span></span>
+            <span class="flex items-center gap-1.5"><i data-lucide="shield-alert" class="w-3 h-3 text-red-400"></i><span id="hdr-fail">0 Failing</span></span>
+            <div class="w-px h-4 bg-slate-700/60"></div>
+            <button onclick="exportReport()" class="flex items-center gap-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 px-3 py-1.5 rounded-lg text-[10px] font-semibold transition-colors">
+                <i data-lucide="download" class="w-3 h-3"></i> Export
+            </button>
+        </div>
+    </header>
+
+    <!-- Views -->
+    <div class="flex-grow relative overflow-hidden">
+
+        <!-- ═══════════════ TOPOLOGY ═══════════════ -->
+        <div id="view-topology" class="absolute inset-0 flex z-10">
+            <div class="flex-grow relative canvas-bg" id="canvas-wrap">
+                <!-- HUD -->
+                <div class="absolute top-3 left-3 z-20 bg-[#0a1628]/90 border border-slate-800 rounded-lg p-1 flex gap-0.5 backdrop-blur">
+                    <button title="Zoom In" class="p-1.5 text-slate-400 hover:text-white hover:bg-slate-800/60 rounded transition-colors"><i data-lucide="zoom-in" class="w-3.5 h-3.5"></i></button>
+                    <button title="Zoom Out" class="p-1.5 text-slate-400 hover:text-white hover:bg-slate-800/60 rounded transition-colors"><i data-lucide="zoom-out" class="w-3.5 h-3.5"></i></button>
+                    <div class="w-px h-4 bg-slate-700 my-auto mx-0.5"></div>
+                    <button title="Reset layout" onclick="resetLayout()" class="p-1.5 text-slate-400 hover:text-white hover:bg-slate-800/60 rounded transition-colors"><i data-lucide="maximize-2" class="w-3.5 h-3.5"></i></button>
+                </div>
+                <svg id="svg-edges" class="absolute inset-0 w-full h-full pointer-events-none z-0"></svg>
+                <div id="div-nodes" class="absolute inset-0 w-full h-full z-10"></div>
+            </div>
+
+            <!-- Topology detail panel -->
+            <aside id="topo-panel" class="w-72 bg-[#0a1628] border-l border-slate-800/60 flex flex-col shrink-0 absolute right-0 top-0 bottom-0 z-30 slide-right closed shadow-2xl">
+                <div class="p-4 border-b border-slate-800/60 flex justify-between items-start">
+                    <div class="flex items-center gap-3">
+                        <div id="tp-icon-wrap" class="w-10 h-10 rounded-xl bg-slate-900 border border-slate-700/60 flex items-center justify-center">
+                            <i id="tp-icon" data-lucide="server" class="w-5 h-5 text-slate-300"></i>
+                        </div>
+                        <div>
+                            <h2 id="tp-title" class="text-sm font-bold text-white">—</h2>
+                            <p id="tp-kind" class="text-[10px] text-slate-500 font-mono uppercase tracking-widest mt-0.5">Service</p>
+                        </div>
+                    </div>
+                    <button onclick="closeTopoPanel()" class="text-slate-500 hover:text-white p-1 transition-colors"><i data-lucide="x" class="w-4 h-4"></i></button>
+                </div>
+                <div class="flex-grow overflow-y-auto p-4 space-y-5">
+                    <!-- Anomaly box -->
+                    <div id="tp-anomaly" class="hidden bg-red-500/8 border border-red-500/25 rounded-xl p-3">
+                        <h4 class="text-[10px] font-bold text-red-400 uppercase tracking-widest mb-1.5 flex items-center gap-1.5"><i data-lucide="brain-circuit" class="w-3.5 h-3.5"></i> Detected Anomaly</h4>
+                        <p id="tp-anomaly-text" class="text-xs text-slate-300 leading-relaxed"></p>
+                        <button onclick="switchTab('incidents')" class="mt-3 w-full text-center text-xs font-semibold text-white bg-slate-800 hover:bg-slate-700 border border-slate-700 py-1.5 rounded-lg transition-colors flex items-center justify-center gap-1.5">
+                            View Details <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                        </button>
+                    </div>
+                    <!-- Live telemetry -->
+                    <div>
+                        <h3 class="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2">Live Telemetry</h3>
+                        <div class="grid grid-cols-2 gap-2">
+                            <div class="bg-slate-900/80 border border-slate-800/60 rounded-xl p-2.5">
+                                <div class="flex justify-between items-center mb-2">
+                                    <span class="text-[10px] text-slate-400 flex items-center gap-1 font-medium"><i data-lucide="cpu" class="w-3 h-3 text-blue-400"></i> CPU</span>
+                                    <span id="tp-cpu-val" class="text-xs font-bold text-white font-mono">--%</span>
+                                </div>
+                                <div class="metric-bar-wrap" id="tp-cpu-bars"></div>
+                            </div>
+                            <div class="bg-slate-900/80 border border-slate-800/60 rounded-xl p-2.5">
+                                <div class="flex justify-between items-center mb-2">
+                                    <span class="text-[10px] text-slate-400 flex items-center gap-1 font-medium"><i data-lucide="hard-drive" class="w-3 h-3 text-purple-400"></i> MEM</span>
+                                    <span id="tp-mem-val" class="text-xs font-bold text-white font-mono">--%</span>
+                                </div>
+                                <div class="metric-bar-wrap" id="tp-mem-bars"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Resource status -->
+                    <div>
+                        <h3 class="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2">Resource Status</h3>
+                        <div class="bg-slate-900/80 border border-slate-800/60 rounded-xl p-3 text-xs font-mono space-y-2">
+                            <div class="flex justify-between pb-2 border-b border-slate-800/40">
+                                <span class="text-slate-500">Replicas</span>
+                                <span id="tp-replicas" class="font-bold">—</span>
+                            </div>
+                            <div class="flex justify-between pb-2 border-b border-slate-800/40">
+                                <span class="text-slate-500">Restarts</span>
+                                <span id="tp-restarts" class="text-slate-300 font-bold">0</span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span class="text-slate-500">Request Rate</span>
+                                <span id="tp-rps" class="text-slate-300">—</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Linked traces button -->
+                    <button id="tp-traces-btn" onclick="openServiceTraces()" class="hidden w-full flex items-center justify-center gap-1.5 text-xs font-medium text-indigo-400 bg-indigo-500/8 hover:bg-indigo-500/15 border border-indigo-500/20 py-2 rounded-lg transition-colors">
+                        <i data-lucide="git-branch" class="w-3.5 h-3.5"></i> View Traces
+                    </button>
+                </div>
+            </aside>
+        </div>
+
+        <!-- ═══════════════ INCIDENTS ═══════════════ -->
+        <div id="view-incidents" class="absolute inset-0 hidden flex z-10 bg-[#020817]">
+            <!-- List -->
+            <div class="w-80 shrink-0 border-r border-slate-800/60 flex flex-col bg-[#0a1628]/40">
+                <div class="px-4 py-3 border-b border-slate-800/60 flex justify-between items-center bg-[#0a1628]/80">
+                    <h2 class="font-bold text-white text-sm flex items-center gap-2"><i data-lucide="alert-triangle" class="w-4 h-4 text-red-400"></i> Active Incidents</h2>
+                    <span id="inc-total" class="text-[10px] bg-slate-800 text-slate-400 px-2 py-0.5 rounded font-mono">0 Total</span>
+                </div>
+                <div class="px-3 py-2 border-b border-slate-800/40">
+                    <input id="inc-search" type="text" placeholder="Search incidents…" oninput="filterIncidents()" class="w-full bg-slate-900/60 border border-slate-700/60 rounded-lg px-3 py-1.5 text-xs text-slate-300 placeholder-slate-600 focus:outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/20 transition-colors">
+                </div>
+                <div class="flex gap-1 px-3 py-2 border-b border-slate-800/40">
+                    <button onclick="setIncPhase('')" id="ifil-all" class="px-2 py-0.5 rounded text-[10px] font-bold bg-indigo-500/15 text-indigo-400 border border-indigo-500/30 transition-colors">All</button>
+                    <button onclick="setIncPhase('Active')" id="ifil-active" class="px-2 py-0.5 rounded text-[10px] font-bold bg-slate-800 text-slate-400 border border-slate-700 hover:border-red-500/40 transition-colors">Active</button>
+                    <button onclick="setIncPhase('Detecting')" id="ifil-detecting" class="px-2 py-0.5 rounded text-[10px] font-bold bg-slate-800 text-slate-400 border border-slate-700 hover:border-purple-500/40 transition-colors">Detecting</button>
+                    <button onclick="setIncPhase('Resolved')" id="ifil-resolved" class="px-2 py-0.5 rounded text-[10px] font-bold bg-slate-800 text-slate-400 border border-slate-700 hover:border-emerald-500/40 transition-colors">Resolved</button>
+                </div>
+                <div class="flex-grow overflow-y-auto" id="inc-list"></div>
+            </div>
+            <!-- Detail -->
+            <div id="inc-detail" class="flex-grow flex flex-col hidden overflow-hidden">
+                <!-- Detail header -->
+                <div class="px-6 py-4 border-b border-slate-800/60 bg-[#0a1628]/60 shrink-0 flex justify-between items-start">
+                    <div>
+                        <div class="flex items-center gap-2 mb-2">
+                            <span id="id-sev" class="px-2 py-0.5 rounded text-[10px] font-bold font-mono border">P1</span>
+                            <span id="id-phase" class="px-2 py-0.5 rounded text-[10px] font-bold font-mono flex items-center gap-1.5 border">Active</span>
+                            <span id="id-type" class="px-2 py-0.5 bg-slate-800 text-slate-400 rounded text-[10px] font-mono border border-slate-700"></span>
+                        </div>
+                        <h2 id="id-title" class="text-xl font-bold text-white tracking-tight"></h2>
+                        <p id="id-meta" class="text-[11px] text-slate-500 font-mono mt-1"></p>
+                    </div>
+                    <div class="text-right">
+                        <div class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mb-0.5">Time Elapsed</div>
+                        <div id="id-elapsed" class="text-base font-mono font-bold text-amber-400">—</div>
+                    </div>
+                </div>
+                <div class="flex-grow overflow-y-auto p-6 space-y-5">
+                    <!-- Summary -->
+                    <section>
+                        <h3 class="sec-title text-purple-400">
+                            <i data-lucide="brain-circuit" class="w-3.5 h-3.5"></i> Operator Summary
+                        </h3>
+                        <div class="bg-purple-500/5 border border-purple-500/20 rounded-xl p-4">
+                            <p id="id-summary" class="text-xs text-slate-300 leading-relaxed">—</p>
+                        </div>
+                    </section>
+                    <!-- Playbook -->
+                    <section>
+                        <h3 class="sec-title text-emerald-400"><i data-lucide="terminal-square" class="w-3.5 h-3.5"></i> Playbook</h3>
+                        <div class="bg-slate-900/60 border border-slate-800/60 rounded-xl p-2 space-y-1.5" id="id-playbook"></div>
+                    </section>
+                    <!-- Resources + Conditions grid -->
+                    <div class="grid grid-cols-1 xl:grid-cols-2 gap-5">
+                        <section>
+                            <h3 class="sec-title text-slate-400"><i data-lucide="layers" class="w-3.5 h-3.5"></i> Affected Resources</h3>
+                            <div class="space-y-1.5" id="id-resources"></div>
+                        </section>
+                        <section>
+                            <h3 class="sec-title text-slate-400"><i data-lucide="check-circle-2" class="w-3.5 h-3.5"></i> Conditions</h3>
+                            <div class="bg-slate-900/60 border border-slate-800/60 rounded-xl overflow-hidden text-xs" id="id-conditions"></div>
+                        </section>
+                    </div>
+                    <!-- Correlated signals -->
+                    <section id="id-signals-section" class="hidden">
+                        <h3 class="sec-title text-blue-400"><i data-lucide="share-2" class="w-3.5 h-3.5"></i> Correlated Signals</h3>
+                        <div class="flex flex-wrap gap-1.5" id="id-signals"></div>
+                    </section>
+                    <!-- Timeline -->
+                    <section id="id-timeline-section" class="hidden">
+                        <h3 class="sec-title text-amber-400"><i data-lucide="list-ordered" class="w-3.5 h-3.5"></i> Event Timeline</h3>
+                        <div class="space-y-1" id="id-timeline"></div>
+                    </section>
+                    <!-- AI RCA block -->
+                    <section id="id-rca-section" class="hidden">
+                        <h3 class="sec-title text-indigo-400"><i data-lucide="sparkles" class="w-3.5 h-3.5"></i> AI Root Cause Analysis</h3>
+                        <div class="bg-indigo-500/5 border border-indigo-500/20 rounded-xl p-4 space-y-3">
+                            <div id="id-rca-cause" class="text-xs text-slate-300 leading-relaxed"></div>
+                            <div id="id-rca-confidence" class="text-[10px] font-mono text-slate-500"></div>
+                        </div>
+                    </section>
+                </div>
+            </div>
+            <div id="inc-empty" class="flex-grow flex flex-col items-center justify-center text-slate-600">
+                <i data-lucide="shield-alert" class="w-10 h-10 mb-3 opacity-20"></i>
+                <p class="text-sm font-medium">Select an incident to view details</p>
+            </div>
+        </div>
+
+        <!-- ═══════════════ METRICS ═══════════════ -->
+        <div id="view-metrics" class="absolute inset-0 hidden flex flex-col bg-[#020817] z-10">
+            <div class="px-6 py-4 border-b border-slate-800/60 bg-[#0a1628]/60 shrink-0 flex items-center justify-between">
+                <div>
+                    <h2 class="text-base font-bold text-white">Cluster Metrics</h2>
+                    <p class="text-[11px] text-slate-500 mt-0.5">Aggregated over selected window</p>
+                </div>
+                <div class="flex items-center gap-2">
+                    <select id="metrics-svc" onchange="onMetricsSvcChange()" class="bg-slate-800 border border-slate-700 text-slate-300 text-xs rounded-lg px-2 py-1.5 focus:outline-none focus:border-indigo-500/60 transition-colors"></select>
+                    <select id="metrics-range" onchange="loadMetrics()" class="bg-slate-800 border border-slate-700 text-slate-300 text-xs rounded-lg px-2 py-1.5 focus:outline-none focus:border-indigo-500/60 transition-colors">
+                        <option value="15">Last 15m</option>
+                        <option value="60" selected>Last 1h</option>
+                        <option value="360">Last 6h</option>
+                        <option value="1440">Last 24h</option>
+                    </select>
+                    <button onclick="loadMetrics()" class="text-xs bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5"><i data-lucide="refresh-cw" class="w-3 h-3"></i> Refresh</button>
+                </div>
+            </div>
+            <div class="flex-grow overflow-y-auto p-6">
+                <div id="metrics-grid" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5"></div>
+            </div>
+        </div>
+
+        <!-- ═══════════════ LOGS ═══════════════ -->
+        <div id="view-logs" class="absolute inset-0 hidden flex flex-col bg-[#020817] z-10">
+            <div class="px-6 py-4 border-b border-slate-800/60 bg-[#0a1628]/60 shrink-0 flex items-center justify-between">
+                <h2 class="text-base font-bold text-white flex items-center gap-2"><i data-lucide="terminal" class="w-4 h-4 text-indigo-400"></i> Unified Log Stream</h2>
+                <div class="flex items-center gap-2">
+                    <select id="logs-svc" onchange="loadLogs()" class="bg-slate-800 border border-slate-700 text-slate-300 text-xs rounded-lg px-2 py-1.5 focus:outline-none focus:border-indigo-500/60 transition-colors"></select>
+                    <select id="logs-sev" onchange="loadLogs()" class="bg-slate-800 border border-slate-700 text-slate-300 text-xs rounded-lg px-2 py-1.5 focus:outline-none focus:border-indigo-500/60 transition-colors">
+                        <option value="">All Levels</option>
+                        <option value="INFO">INFO</option>
+                        <option value="WARN">WARN</option>
+                        <option value="ERROR">ERROR</option>
+                        <option value="FATAL">FATAL</option>
+                    </select>
+                    <button onclick="loadLogs()" class="text-xs bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5"><i data-lucide="refresh-cw" class="w-3 h-3"></i> Refresh</button>
+                    <button onclick="toggleLogScroll()" id="log-scroll-btn" class="text-xs bg-indigo-500/15 border border-indigo-500/30 text-indigo-400 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5"><i data-lucide="arrow-down-to-line" class="w-3 h-3"></i> Auto-scroll</button>
+                </div>
+            </div>
+            <div class="flex-grow bg-[#060d1a] border-b border-slate-800/60 flex flex-col overflow-hidden">
+                <div class="h-7 bg-[#0a1628] border-b border-slate-800/60 flex items-center px-4 gap-2 shrink-0">
+                    <div class="w-2.5 h-2.5 rounded-full bg-red-500/40"></div>
+                    <div class="w-2.5 h-2.5 rounded-full bg-yellow-500/40"></div>
+                    <div class="w-2.5 h-2.5 rounded-full bg-emerald-500/40"></div>
+                    <span id="logs-cmd" class="text-[10px] text-slate-600 font-mono ml-2">tail -f /var/log/containers/*.log</span>
+                </div>
+                <div id="logs-stream" class="flex-grow overflow-y-auto p-4 space-y-0.5"></div>
+            </div>
+        </div>
+
+        <!-- ═══════════════ TRACES ═══════════════ -->
+        <div id="view-traces" class="absolute inset-0 hidden flex flex-col bg-[#020817] z-10">
+            <div class="px-6 py-4 border-b border-slate-800/60 bg-[#0a1628]/60 shrink-0 flex items-center justify-between">
+                <h2 class="text-base font-bold text-white flex items-center gap-2"><i data-lucide="git-branch" class="w-4 h-4 text-indigo-400"></i> Distributed Traces</h2>
+                <div class="flex items-center gap-2">
+                    <select id="traces-svc" onchange="loadTraces()" class="bg-slate-800 border border-slate-700 text-slate-300 text-xs rounded-lg px-2 py-1.5 focus:outline-none focus:border-indigo-500/60 transition-colors"></select>
+                    <button onclick="loadTraces()" class="text-xs bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5"><i data-lucide="refresh-cw" class="w-3 h-3"></i> Refresh</button>
+                </div>
+            </div>
+            <div class="flex-grow overflow-y-auto p-6">
+                <div class="bg-[#0a1628] border border-slate-800/60 rounded-xl overflow-hidden">
+                    <table class="w-full text-left text-xs">
+                        <thead class="text-[10px] text-slate-500 uppercase bg-[#060d1a] border-b border-slate-800/60">
+                            <tr>
+                                <th class="px-4 py-3 font-bold">Trace ID</th>
+                                <th class="px-4 py-3 font-bold">Root Operation</th>
+                                <th class="px-4 py-3 font-bold">Duration</th>
+                                <th class="px-4 py-3 font-bold">Spans</th>
+                                <th class="px-4 py-3 font-bold">Status</th>
+                                <th class="px-4 py-3 font-bold text-right">Time</th>
+                            </tr>
+                        </thead>
+                        <tbody id="traces-body" class="divide-y divide-slate-800/40"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- ═══════════════ RCA RULES ═══════════════ -->
+        <div id="view-rules" class="absolute inset-0 hidden flex flex-col bg-[#020817] z-10">
+            <div class="px-6 py-4 border-b border-slate-800/60 bg-[#0a1628]/60 shrink-0 flex items-center justify-between">
+                <div>
+                    <h2 class="text-base font-bold text-white">RCA Correlation Rules</h2>
+                    <p class="text-[11px] text-slate-500 mt-0.5">Operator-evaluated signal correlation logic</p>
+                </div>
+                <span id="rules-count" class="text-[10px] bg-slate-800 text-slate-400 px-2 py-0.5 rounded font-mono">0 Rules</span>
+            </div>
+            <div class="flex-grow overflow-y-auto p-6">
+                <div class="bg-[#0a1628] border border-slate-800/60 rounded-xl overflow-hidden">
+                    <table class="w-full text-left text-xs">
+                        <thead class="text-[10px] text-slate-500 uppercase bg-[#060d1a] border-b border-slate-800/60">
+                            <tr>
+                                <th class="px-4 py-3 font-bold w-8">P</th>
+                                <th class="px-4 py-3 font-bold">Rule Name</th>
+                                <th class="px-4 py-3 font-bold">Trigger Event</th>
+                                <th class="px-4 py-3 font-bold">Fires As</th>
+                                <th class="px-4 py-3 font-bold">Severity</th>
+                                <th class="px-4 py-3 font-bold">Conditions</th>
+                                <th class="px-4 py-3 font-bold">Scope</th>
+                                <th class="px-4 py-3 font-bold text-right">Age</th>
+                            </tr>
+                        </thead>
+                        <tbody id="rules-body" class="divide-y divide-slate-800/40"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- ═══════════════ RCA AGENTS ═══════════════ -->
+        <div id="view-agents" class="absolute inset-0 hidden flex flex-col bg-[#020817] z-10">
+            <div class="px-6 py-4 border-b border-slate-800/60 bg-[#0a1628]/60 shrink-0 flex items-center justify-between">
+                <div>
+                    <h2 class="text-base font-bold text-white">RCA Agents</h2>
+                    <p class="text-[11px] text-slate-500 mt-0.5">Active collectors and their watch configuration</p>
+                </div>
+                <button onclick="refreshAgents()" class="text-xs bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5"><i data-lucide="refresh-cw" class="w-3 h-3"></i> Refresh</button>
+            </div>
+            <div class="flex-grow overflow-y-auto p-6 space-y-4" id="agents-grid"></div>
+        </div>
+
+    </div><!-- end views -->
+
+    <!-- Correlation Stream (persistent bottom) -->
+    <div class="h-44 bg-[#0a1628] border-t border-slate-800/60 shrink-0 flex flex-col z-40 shadow-[0_-8px_30px_rgba(0,0,0,0.4)]">
+        <div class="flex items-center justify-between px-5 py-2 border-b border-slate-800/40 shrink-0">
+            <h3 class="text-[10px] font-bold text-slate-500 uppercase tracking-widest flex items-center gap-1.5">
+                <i data-lucide="activity" class="w-3.5 h-3.5 text-indigo-400"></i> Live Correlation Stream
+            </h3>
+            <div class="flex items-center gap-2">
+                <span id="sse-status" class="text-[10px] font-mono text-slate-600 flex items-center gap-1"></span>
+            </div>
+        </div>
+        <div class="flex-grow overflow-x-auto overflow-y-hidden relative" id="stream-wrap">
+            <div class="tl-line"></div>
+            <div class="flex gap-3 min-w-max items-start h-full px-4 py-3 relative z-10" id="stream-cards"></div>
+        </div>
+    </div>
+
+</main>
+
+<!-- Toast -->
+<div id="toast" class="fixed bottom-[-80px] left-1/2 -translate-x-1/2 bg-slate-800 border border-slate-700 text-white px-4 py-2 rounded-xl shadow-2xl text-xs font-medium z-[200] opacity-0 flex items-center gap-2">
+    <i data-lucide="info" class="w-3.5 h-3.5 text-indigo-400"></i>
+    <span id="toast-msg"></span>
 </div>
 
+<style>
+.sec-title { @apply text-[10px] font-bold uppercase tracking-widest mb-2 flex items-center gap-1.5; }
+</style>
+
 <script>
-(function(){
-  /* ── State ─────────────────────────────────── */
-  var incidents=[], stats={}, rules=[], topoGraph=null, topoBlast=[];
-  var activeTab='incidents', selectedKey=null, signalsOpen=true, topoSelectedNode=null;
-  var filters={phase:'all',ns:'all',sev:'all',type:'all'};
-  var connected=false;
-  var themeKey='rca-theme';
-  var tzKey='rca-tz';
-  var browserTZ=(function(){try{return Intl.DateTimeFormat().resolvedOptions().timeZone||'UTC'}catch(e){return'UTC'}})();
-  var tzOptions=(function(){
-    var z=[];try{if(Intl.supportedValuesOf)z=Intl.supportedValuesOf('timeZone')||[]}catch(e){}
-    if(!z.length)z=['UTC',browserTZ,'America/Los_Angeles','America/Denver','America/Chicago','America/New_York','Europe/London','Europe/Berlin','Asia/Kolkata','Asia/Singapore','Asia/Tokyo','Australia/Sydney'];
-    var u={},list=['Local'];z.forEach(function(zone){if(!zone||u[zone])return;u[zone]=true;list.push(zone)});
-    if(!u.UTC)list.splice(1,0,'UTC');return list;
-  })();
-  var selTZ=(function(){try{var s=localStorage.getItem(tzKey);if(s&&tzOptions.indexOf(s)!==-1)return s}catch(e){}return'UTC'})();
-  var theme=(function(){try{return localStorage.getItem(themeKey)||'dark'}catch(e){return'dark'}})();
+(function() {
+'use strict';
 
-  var SEV_COLORS={P1:'var(--red)',P2:'var(--amber)',P3:'var(--blue)',P4:'var(--text-tertiary)'};
+// ── Constants ──────────────────────────────────────────────────────────────
+const POLL_INTERVAL = 15000; // 15s data refresh
+const SEV_BADGE = {
+    P1: 'bg-red-500/10 text-red-400 border-red-500/30',
+    P2: 'bg-amber-500/10 text-amber-400 border-amber-500/30',
+    P3: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+    P4: 'bg-slate-700/30 text-slate-300 border-slate-600/60',
+};
+const PHASE_BADGE = {
+    Active:    'bg-red-500/10 text-red-400 border-red-500/30',
+    Detecting: 'bg-purple-500/10 text-purple-400 border-purple-500/30',
+    Resolved:  'bg-emerald-500/10 text-emerald-400 border-emerald-500/30',
+};
+const LOG_COLOR = {
+    INFO:  'text-emerald-400',
+    DEBUG: 'text-slate-500',
+    TRACE: 'text-slate-600',
+    WARN:  'text-amber-400',
+    ERROR: 'text-red-400',
+    FATAL: 'text-red-300',
+    K8S:   'text-indigo-400',
+};
+const STREAM_SOURCE_COLOR = {
+    prometheus:   'border-blue-500/30 bg-blue-500/8 text-blue-400',
+    jaeger:       'border-violet-500/30 bg-violet-500/8 text-violet-400',
+    signoz:       'border-slate-500/30 bg-slate-800 text-slate-400',
+    'rca-operator': 'border-red-500/40 bg-red-500/10 text-red-400',
+    ai:           'border-purple-500/30 bg-purple-500/8 text-purple-400',
+};
+const PLAYBOOK_DB = {
+    OOMKilled:       ['kubectl top pod -n <ns>', 'kubectl describe pod <pod> -n <ns>', 'kubectl get limitrange -n <ns>'],
+    CrashLoopBackOff:['kubectl logs <pod> -n <ns> --previous', 'kubectl describe pod <pod> -n <ns>'],
+    ImagePullBackOff:['kubectl describe pod <pod> -n <ns>', 'kubectl get secret -n <ns> | grep docker'],
+    NodeNotReady:    ['kubectl describe node <node>', 'kubectl get events --sort-by=.lastTimestamp'],
+    StalledRollout:  ['kubectl rollout history deployment/<name> -n <ns>', 'kubectl rollout undo deployment/<name> -n <ns>'],
+    ProbeFailure:    ['kubectl describe pod <pod> -n <ns>', 'kubectl logs <pod> -n <ns>'],
+    PodEvicted:      ['kubectl get events -n <ns> --sort-by=.lastTimestamp', 'kubectl top node'],
+    NodePressure:    ['kubectl describe node <node>', 'kubectl top node'],
+};
+const NODE_LAYOUT = {
+    ingress:        {x:15,y:35}, 'api-gateway':{x:32,y:50}, 'auth-svc':{x:50,y:22},
+    'payment-svc':  {x:50,y:50}, 'inventory-svc':{x:50,y:78}, 'redis-cache':{x:68,y:30},
+    'postgres-db':  {x:68,y:70},
+};
 
-  var PLAYBOOK={
-    NodeNotReady:['kubectl describe node <node-name>','kubectl get events -n <ns> --sort-by=\'.lastTimestamp\'','kubectl get pods -n <ns> -o wide | grep <node-name>'],
-    StalledRollout:['kubectl rollout history deployment/<name> -n <ns>','kubectl rollout undo deployment/<name> -n <ns>','kubectl logs deployment/<name> -n <ns> --previous'],
-    OOMKilled:['kubectl top pod -n <ns>','kubectl describe pod <pod-name> -n <ns>','kubectl get limitrange -n <ns>'],
-    ImagePullBackOff:['kubectl describe pod <pod-name> -n <ns>','kubectl get secret -n <ns> | grep docker','kubectl create secret docker-registry regcred ...'],
-    CrashLoopBackOff:['kubectl logs <pod-name> -n <ns> --previous','kubectl describe pod <pod-name> -n <ns>','kubectl get events -n <ns> --field-selector involvedObject.name=<pod>'],
-    GracePeriodViolation:['kubectl describe pod <pod-name> -n <ns>','kubectl get pod <pod-name> -n <ns> -o yaml | grep terminationGracePeriod'],
-    ProbeFailure:['kubectl describe pod <pod-name> -n <ns>','kubectl logs <pod-name> -n <ns>'],
-    /* Legacy aliases for backward compat */
-    NodeFailure:['kubectl describe node <node-name>','kubectl get events -n <ns> --sort-by=\'.lastTimestamp\''],
-    BadDeploy:['kubectl rollout history deployment/<name> -n <ns>','kubectl rollout undo deployment/<name> -n <ns>'],
-    OOM:['kubectl top pod -n <ns>','kubectl describe pod <pod-name> -n <ns>'],
-    Registry:['kubectl describe pod <pod-name> -n <ns>','kubectl get secret -n <ns> | grep docker'],
-    CrashLoop:['kubectl logs <pod-name> -n <ns> --previous','kubectl describe pod <pod-name> -n <ns>']
-  };
+// ── State ──────────────────────────────────────────────────────────────────
+const S = {
+    tab: 'topology',
+    incidents: [], stats: {active:0,detecting:0,resolved:0,namespaces:{},agents:[]},
+    rules: [], agents: [],
+    topoGraph: {nodes:{},edges:[]},
+    nodesData: [], edgesData: [], nodePositions: {},
+    selectedIncKey: null, selectedNode: null, selectedSvc: '',
+    incPhaseFilter: '', incQuery: '',
+    metricsCache: {}, logsCache: {}, tracesCache: {},
+    sseConn: null, sseStreamEvents: [],
+    logAutoScroll: true,
+    pollTimer: null,
+};
+let dragNode = null, dragOX = 0, dragOY = 0, isDragging = false, toastTimer;
 
-  /* ── Helpers ───────────────────────────────── */
-  function esc(s){if(!s)return'';var el=document.createElement('span');el.textContent=s;return el.innerHTML}
-  function activeTZ(){return selTZ==='Local'?browserTZ:selTZ}
+// ── Helpers ────────────────────────────────────────────────────────────────
+const $  = id => document.getElementById(id);
+const esc = v => v == null ? '' : String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+const clamp = (v,a,b) => Math.min(b,Math.max(a,v));
+const num = (v,fb=0) => { const n=Number(v); return isFinite(n)?n:fb; };
 
-  function pulseDot(color,sz){
-    sz=sz||8;
-    return '<span class="pulse-dot" style="width:'+sz+'px;height:'+sz+'px">'+
-      '<span class="ring" style="background:'+color+'"></span>'+
-      '<span class="dot" style="background:'+color+'"></span></span>';
-  }
-
-  function fmtClock(d,tz){
-    try{var p=new Intl.DateTimeFormat('en-GB',{hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false,timeZone:tz}).formatToParts(d);
-    var m={};p.forEach(function(x){m[x.type]=x.value});if(m.hour)return m.hour+':'+m.minute+':'+m.second}catch(e){}return d.toISOString().slice(11,19);
-  }
-  function fmtZone(d,tz){
-    try{var p=new Intl.DateTimeFormat('en-US',{timeZone:tz,timeZoneName:'short'}).formatToParts(d);
-    for(var i=0;i<p.length;i++){if(p[i].type==='timeZoneName')return p[i].value}}catch(e){}return tz==='UTC'?'UTC':tz;
-  }
-  function relTime(iso){
-    if(!iso)return'';var d=Math.floor((Date.now()-new Date(iso).getTime())/1000);
-    if(d<0)d=0;if(d<60)return d+'s ago';if(d<3600)return Math.floor(d/60)+'m ago';
-    return Math.floor(d/3600)+'h '+Math.floor((d%3600)/60)+'m ago';
-  }
-  function absTime(iso){
-    if(!iso)return'';try{var d=new Date(iso);if(isNaN(d.getTime()))return'';var z=activeTZ();return fmtClock(d,z)+' '+fmtZone(d,z)}catch(e){return''}
-  }
-  function liveDur(iso){
-    if(!iso)return'';var d=Math.floor((Date.now()-new Date(iso).getTime())/1000);if(d<0)d=0;
-    var h=Math.floor(d/3600),m=Math.floor((d%3600)/60),s=d%60;
-    if(h>0)return h+'h '+m+'m '+s+'s';if(m>0)return m+'m '+s+'s';return s+'s';
-  }
-  function finDur(s,e){
-    if(!s||!e)return'';var d=Math.floor((new Date(e)-new Date(s))/1000);if(d<0||isNaN(d))return'';
-    var h=Math.floor(d/3600),m=Math.floor((d%3600)/60),sec=d%60;
-    if(h>0)return h+'h '+m+'m '+sec+'s';return m+'m '+sec+'s';
-  }
-  function incKey(i){return i.name+'/'+i.namespace}
-  function startTime(i){return i.firstObservedAt||i.startTime||''}
-  function resolvedTime(i){return i.resolvedAt||i.resolvedTime||''}
-  function findRes(i,k){var r=i.affectedResources||[];for(var j=0;j<r.length;j++){if(r[j].kind===k)return r[j]}return null}
-  function primaryRef(i){
-    if(i.scope&&i.scope.resourceRef&&i.scope.resourceRef.name)return i.scope.resourceRef;
-    if(i.scope&&i.scope.workloadRef&&i.scope.workloadRef.name)return i.scope.workloadRef;
-    return findRes(i,'Node')||findRes(i,'Deployment')||findRes(i,'StatefulSet')||
-      findRes(i,'DaemonSet')||findRes(i,'Job')||findRes(i,'CronJob')||
-      findRes(i,'ReplicaSet')||findRes(i,'Pod');
-  }
-  function dname(i){var r=primaryRef(i);return(r&&r.name)||i.podName||i.name}
-  function pad(n){return n<10?'0'+n:''+n}
-
-  function copyToClip(text,btn){
-    try{navigator.clipboard.writeText(text)}catch(e){}
-    if(btn){btn.textContent='\u2713';btn.className='copy-btn ok';
-    setTimeout(function(){btn.textContent='copy';btn.className='copy-btn'},1500)}
-  }
-
-  /* ── Theme ─────────────────────────────────── */
-  function applyTheme(t){
-    theme=t;document.documentElement.setAttribute('data-theme',t);
-    try{localStorage.setItem(themeKey,t)}catch(e){}
-  }
-  applyTheme(theme);
-
-  /* ── Fetch ─────────────────────────────────── */
-  function fetchAll(){
-    Promise.all([
-      fetch('/api/incidents').then(function(r){return r.json()}),
-      fetch('/api/stats').then(function(r){return r.json()}),
-      fetch('/api/rules').then(function(r){return r.json()}).catch(function(){return[]})
-    ]).then(function(res){
-      incidents=res[0]||[];stats=res[1]||{};rules=res[2]||[];connected=true;
-      document.getElementById('conn-dot').innerHTML=pulseDot('var(--green)',8);
-      render();
-      fetchTopology();
-    }).catch(function(){
-      connected=false;
-      document.getElementById('conn-dot').innerHTML='<span style="width:8px;height:8px;border-radius:50%;background:var(--red);display:inline-block"></span>';
-      renderStatusBar();
-    });
-  }
-
-  /* ── Filter ────────────────────────────────── */
-  function getFiltered(){
-    return incidents.filter(function(i){
-      if(filters.phase!=='all'&&i.phase!==filters.phase)return false;
-      if(filters.ns!=='all'&&i.namespace!==filters.ns)return false;
-      if(filters.sev!=='all'&&i.severity!==filters.sev)return false;
-      if(filters.type!=='all'&&i.incidentType!==filters.type)return false;
-      return true;
-    });
-  }
-  function getSorted(list){
-    var rank={P1:4,P2:3,P3:2,P4:1};
-    return list.slice().sort(function(a,b){
-      var d=(rank[b.severity]||0)-(rank[a.severity]||0);
-      if(d!==0)return d;
-      return startTime(b).localeCompare(startTime(a));
-    });
-  }
-
-  /* ── Topology ──────────────────────────────── */
-  function fetchTopology(){
-    fetch('/api/topology').then(function(r){return r.json()}).then(function(data){
-      topoGraph=data;if(activeTab==='topology')renderTopology();
-    }).catch(function(){});
-  }
-
-  function fetchBlastRadius(svc){
-    fetch('/api/topology/blast?service='+encodeURIComponent(svc)).then(function(r){return r.json()}).then(function(data){
-      topoBlast=data||[];if(activeTab==='topology')renderTopology();
-    }).catch(function(){});
-  }
-
-  var ICON_MAP={globe:'\u{1F310}',database:'\u{1F5C4}',mail:'\u{1F4E8}','shield-check':'\u{1F6E1}','credit-card':'\u{1F4B3}',monitor:'\u{1F5A5}',server:'\u{2699}'};
-  var STATUS_FILL={healthy:'var(--green)',warning:'var(--amber)',critical:'var(--red)',unknown:'var(--text-tertiary)'};
-  var STATUS_BG={healthy:'var(--green-soft)',warning:'var(--amber-soft)',critical:'var(--red-soft)',unknown:'var(--bg-hover)'};
-
-  function layoutNodes(nodes){
-    var names=Object.keys(nodes||{});if(!names.length)return{};
-    var positions={};var cols={};
-    // Simple layered layout: group by dependency depth
-    // For now use a force-like grid layout
-    var perRow=Math.ceil(Math.sqrt(names.length));
-    var spacingX=180,spacingY=140,padX=120,padY=80;
-    names.sort().forEach(function(name,i){
-      var row=Math.floor(i/perRow);var col=i%perRow;
-      positions[name]={x:padX+col*spacingX,y:padY+row*spacingY};
-    });
-    return positions;
-  }
-
-  function renderTopology(){
-    var el=document.getElementById('list-pane');
-    document.getElementById('detail-panel').style.display='none';
-    el.className='list-pane full';
-
-    if(!topoGraph||!topoGraph.nodes||Object.keys(topoGraph.nodes).length===0){
-      el.innerHTML='<div class="topo-container"><div class="empty-state" style="margin:auto">'+
-        '<div class="empty-state-title">No topology data available</div>'+
-        '<div class="empty-state-sub">Connect a telemetry backend (SigNoz, Jaeger) to see the service dependency graph</div></div></div>';
-      return;
+function relTime(ts) {
+    if (!ts) return '—';
+    let s = Math.floor((Date.now()-new Date(ts).getTime())/1000);
+    if (s<0) s=0;
+    if (s<60) return `${s}s ago`;
+    if (s<3600) return `${Math.floor(s/60)}m ago`;
+    if (s<86400) return `${Math.floor(s/3600)}h ago`;
+    return `${Math.floor(s/86400)}d ago`;
+}
+function elapsed(start, end) {
+    if (!start) return '—';
+    const ms = (end ? new Date(end) : new Date()).getTime() - new Date(start).getTime();
+    if (isNaN(ms)||ms<0) return '—';
+    const t=Math.floor(ms/1000), h=Math.floor(t/3600), m=Math.floor((t%3600)/60), s=t%60;
+    return h>0?`${h}h ${m}m ${s}s`:m>0?`${m}m ${s}s`:`${s}s`;
+}
+function fmtTime(ts) {
+    if (!ts) return '—';
+    return new Date(ts).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false});
+}
+function fmtDur(ms) {
+    if (!ms) return '—';
+    if (ms < 1) return `${(ms*1000).toFixed(0)}μs`;
+    if (ms < 1000) return `${ms.toFixed(1)}ms`;
+    return `${(ms/1000).toFixed(2)}s`;
+}
+function sevRank(s) { return {P1:4,P2:3,P3:2,P4:1}[s]||0; }
+function incKey(inc) { return `${inc.namespace}/${inc.name}`; }
+function incStart(inc) { return inc.firstObservedAt||inc.activeAt||inc.lastObservedAt||inc.resolvedAt||''; }
+function serviceFor(inc) {
+    if (inc.scope?.resourceRef?.name) return inc.scope.resourceRef.name;
+    if (inc.scope?.workloadRef?.name) return inc.scope.workloadRef.name;
+    const kins = ['Deployment','StatefulSet','DaemonSet','Pod','Node'];
+    for (const k of kins) {
+        const f = (inc.affectedResources||[]).find(r=>r.kind===k&&r.name);
+        if (f) return f.name;
     }
+    return inc.podName||inc.name;
+}
+function chooseIcon(hint, kind, name) {
+    const n=(name||'').toLowerCase(), k=(kind||'').toLowerCase();
+    if (n.includes('redis')||n.includes('cache')||n.includes('db')||n.includes('postgres')||n.includes('mysql')||k.includes('db')) return 'database';
+    if (n.includes('ingress')||n.includes('gateway')||n.includes('nginx')||n.includes('proxy')) return 'globe';
+    if (n.includes('auth')||n.includes('oauth')) return 'shield-check';
+    if (n.includes('payment')||n.includes('billing')) return 'credit-card';
+    if (n.includes('inventory')||n.includes('catalog')) return 'package';
+    return 'server';
+}
+function getServices() {
+    const from_topo = S.nodesData.map(n=>n.id);
+    if (from_topo.length) return from_topo;
+    const from_inc = S.incidents.map(serviceFor).filter(Boolean);
+    return [...new Set(from_inc)];
+}
 
-    var nodes=topoGraph.nodes;var edges=topoGraph.edges||[];
-    var positions=layoutNodes(nodes);
-    var names=Object.keys(nodes);
-    var perRow=Math.ceil(Math.sqrt(names.length));
-    var svgW=Math.max(600,perRow*180+200);
-    var svgH=Math.max(400,Math.ceil(names.length/perRow)*140+160);
-
-    var blastSet={};(topoBlast||[]).forEach(function(s){blastSet[s]=true});
-
-    var h='<div class="topo-container">';
-    h+='<svg class="topo-svg" id="topo-svg" viewBox="0 0 '+svgW+' '+svgH+'" xmlns="http://www.w3.org/2000/svg">';
-
-    // Defs for markers
-    h+='<defs><marker id="arrow-active" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto">';
-    h+='<path d="M0,0 L10,3 L0,6" fill="var(--border-strong)"/></marker>';
-    h+='<marker id="arrow-warning" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto">';
-    h+='<path d="M0,0 L10,3 L0,6" fill="var(--amber)"/></marker>';
-    h+='<marker id="arrow-critical" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto">';
-    h+='<path d="M0,0 L10,3 L0,6" fill="var(--red)"/></marker></defs>';
-
-    // Edges
-    edges.forEach(function(e){
-      var src=positions[e.source];var tgt=positions[e.target];
-      if(!src||!tgt)return;
-      var status=e.status||'active';
-      var markerId='arrow-'+status;
-      // Shorten line to not overlap node circles
-      var dx=tgt.x-src.x,dy=tgt.y-src.y;
-      var dist=Math.sqrt(dx*dx+dy*dy);
-      if(dist<1)return;
-      var r=28; // node radius
-      var sx=src.x+dx/dist*r,sy=src.y+dy/dist*r;
-      var tx=tgt.x-dx/dist*(r+8),ty=tgt.y-dy/dist*(r+8);
-      h+='<line class="edge-line status-'+esc(status)+'" x1="'+sx+'" y1="'+sy+'" x2="'+tx+'" y2="'+ty+'" marker-end="url(#'+markerId+')"/>';
-      // Edge label (call count)
-      if(e.callCount>0){
-        var mx=(sx+tx)/2,my=(sy+ty)/2;
-        h+='<text class="edge-label" x="'+mx+'" y="'+(my-5)+'" text-anchor="middle">'+e.callCount+' calls</text>';
-      }
-    });
-
-    // Nodes
-    names.sort().forEach(function(name){
-      var node=nodes[name];var pos=positions[name];if(!pos)return;
-      var status=node.status||'unknown';
-      var fill=STATUS_FILL[status]||STATUS_FILL.unknown;
-      var bg=STATUS_BG[status]||STATUS_BG.unknown;
-      var isSel=topoSelectedNode===name;
-      var isBlast=blastSet[name];
-      var icon=ICON_MAP[node.icon]||ICON_MAP.server;
-      var r=isSel?32:26;
-
-      h+='<g class="node-group" onclick="window._topoSelect(\''+esc(name)+'\')" transform="translate('+pos.x+','+pos.y+')">';
-      // Blast radius glow
-      if(isBlast){
-        h+='<circle r="'+(r+8)+'" fill="none" stroke="var(--red)" stroke-width="2" stroke-dasharray="4 3" opacity="0.6"/>';
-      }
-      // Selected ring
-      if(isSel){
-        h+='<circle r="'+(r+4)+'" fill="none" stroke="var(--accent)" stroke-width="2"/>';
-      }
-      // Main circle
-      h+='<circle class="node-circle" r="'+r+'" fill="'+bg+'" stroke="'+fill+'"/>';
-      // Icon
-      h+='<text class="node-icon" text-anchor="middle" dominant-baseline="central" y="-2">'+icon+'</text>';
-      // Label
-      h+='<text class="node-label" text-anchor="middle" y="'+(r+16)+'">'+esc(name)+'</text>';
-      // Status sublabel
-      if(node.incidents&&node.incidents.length>0){
-        h+='<text class="node-sublabel" text-anchor="middle" y="'+(r+28)+'">'+node.incidents.length+' incident'+(node.incidents.length>1?'s':'')+'</text>';
-      } else if(node.metrics&&node.metrics.requestRate>0){
-        h+='<text class="node-sublabel" text-anchor="middle" y="'+(r+28)+'">'+Math.round(node.metrics.requestRate)+' req/s</text>';
-      }
-      h+='</g>';
-    });
-
-    h+='</svg>';
-
-    // Legend
-    h+='<div class="topo-legend">';
-    h+='<div class="topo-legend-item"><span class="topo-legend-dot" style="background:var(--green)"></span> Healthy</div>';
-    h+='<div class="topo-legend-item"><span class="topo-legend-dot" style="background:var(--amber)"></span> Warning</div>';
-    h+='<div class="topo-legend-item"><span class="topo-legend-dot" style="background:var(--red)"></span> Critical</div>';
-    h+='<div class="topo-legend-item"><span class="topo-legend-dot" style="background:var(--text-tertiary)"></span> Unknown</div>';
-    h+='</div>';
-
-    // Controls
-    h+='<div class="topo-controls">';
-    h+='<button class="topo-btn" onclick="window._topoRefresh()" title="Refresh">\u21BB</button>';
-    h+='</div>';
-
-    // Side panel
-    if(topoSelectedNode&&nodes[topoSelectedNode]){
-      var sn=nodes[topoSelectedNode];
-      var sm=sn.metrics;
-      h+='<div class="topo-side" style="position:relative">';
-      h+='<div class="topo-side-head">';
-      h+='<div class="topo-side-title">'+(ICON_MAP[sn.icon]||ICON_MAP.server)+' '+esc(topoSelectedNode)+'</div>';
-      h+='<div class="topo-side-subtitle">Status: <span style="color:'+STATUS_FILL[sn.status||'unknown']+'">'+esc(sn.status||'unknown')+'</span></div>';
-      h+='<button class="topo-side-close" onclick="window._topoSelect(null)">\u00d7</button>';
-      h+='</div>';
-      h+='<div class="topo-side-body">';
-
-      // Metrics
-      h+='<div><div class="section-title">Metrics</div>';
-      if(sm){
-        h+='<div class="topo-metric"><span class="topo-metric-label">Req Rate</span><span class="topo-metric-val" style="color:var(--accent)">'+sm.requestRate.toFixed(1)+'/s</span></div>';
-        h+='<div class="topo-metric"><span class="topo-metric-label">Error Rate</span><span class="topo-metric-val" style="color:'+(sm.errorRate>1?'var(--red)':'var(--green)')+'">'+sm.errorRate.toFixed(2)+'%</span></div>';
-        h+='<div class="topo-metric"><span class="topo-metric-label">P99 Latency</span><span class="topo-metric-val" style="color:'+(sm.p99Latency>500?'var(--amber)':'var(--text-primary)')+'">'+sm.p99Latency.toFixed(0)+'ms</span></div>';
-        if(sm.cpuUsage>0)h+='<div class="topo-metric"><span class="topo-metric-label">CPU</span><span class="topo-metric-val">'+sm.cpuUsage.toFixed(1)+'%</span></div>';
-        if(sm.memUsage>0)h+='<div class="topo-metric"><span class="topo-metric-label">Memory</span><span class="topo-metric-val">'+(sm.memUsage/1024/1024).toFixed(0)+' MB</span></div>';
-      } else {
-        h+='<div style="font-size:12px;color:var(--text-tertiary)">No metrics available</div>';
-      }
-      h+='</div>';
-
-      // Incidents
-      if(sn.incidents&&sn.incidents.length>0){
-        h+='<div><div class="section-title">Active Incidents</div>';
-        sn.incidents.forEach(function(inc){
-          h+='<div class="card"><span class="sev sm sev-'+esc(inc.severity)+'">'+esc(inc.severity)+'</span>';
-          h+='<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-primary)">'+esc(inc.name)+'</div>';
-          h+='<div style="font-size:10px;color:var(--text-tertiary)">'+esc(inc.incidentType)+' \u00b7 '+esc(inc.phase)+'</div></div></div>';
-        });
-        h+='</div>';
-      }
-
-      // Blast Radius
-      if(topoBlast&&topoBlast.length>0){
-        h+='<div><div class="section-title">Blast Radius ('+topoBlast.length+' services)</div>';
-        h+='<div style="display:flex;flex-wrap:wrap;gap:2px">';
-        topoBlast.forEach(function(s){
-          h+='<span class="topo-blast-tag">'+esc(s)+'</span>';
-        });
-        h+='</div></div>';
-      }
-
-      // Quick links
-      h+='<div><div class="section-title">Quick Actions</div>';
-      h+='<div class="card" style="cursor:pointer" onclick="window._topoViewTraces(\''+esc(topoSelectedNode)+'\')"><span class="cmd-num">\u{1F50D}</span><code class="cmd-code">View Recent Traces</code></div>';
-      h+='<div class="card" style="cursor:pointer" onclick="window._topoViewLogs(\''+esc(topoSelectedNode)+'\')"><span class="cmd-num">\u{1F4DC}</span><code class="cmd-code">View Recent Logs</code></div>';
-      if(sn.incidents&&sn.incidents.length>0){
-        sn.incidents.forEach(function(inc){
-          h+='<div class="card" style="cursor:pointer" onclick="window._topoInvestigate(\''+esc(inc.namespace)+'\',\''+esc(inc.name)+'\')"><span class="cmd-num">\u{1F916}</span><code class="cmd-code">AI Investigate: '+esc(inc.name)+'</code></div>';
-        });
-      }
-      h+='</div>';
-
-      h+='</div></div>';
-    }
-
-    h+='</div>';
-    el.innerHTML=h;
-
-    // Enable SVG drag/pan
-    initTopoPan();
-  }
-
-  function initTopoPan(){
-    var svg=document.getElementById('topo-svg');if(!svg)return;
-    var viewBox=svg.viewBox.baseVal;
-    var isPanning=false,startX,startY;
-    svg.addEventListener('mousedown',function(e){
-      if(e.target.closest('.node-group'))return;
-      isPanning=true;startX=e.clientX;startY=e.clientY;
-    });
-    svg.addEventListener('mousemove',function(e){
-      if(!isPanning)return;
-      var dx=(e.clientX-startX)*viewBox.width/svg.clientWidth;
-      var dy=(e.clientY-startY)*viewBox.height/svg.clientHeight;
-      viewBox.x-=dx;viewBox.y-=dy;
-      startX=e.clientX;startY=e.clientY;
-    });
-    svg.addEventListener('mouseup',function(){isPanning=false});
-    svg.addEventListener('mouseleave',function(){isPanning=false});
-    svg.addEventListener('wheel',function(e){
-      e.preventDefault();
-      var scale=e.deltaY>0?1.1:0.9;
-      var cx=viewBox.x+viewBox.width/2;
-      var cy=viewBox.y+viewBox.height/2;
-      viewBox.width*=scale;viewBox.height*=scale;
-      viewBox.x=cx-viewBox.width/2;
-      viewBox.y=cy-viewBox.height/2;
-    },{passive:false});
-  }
-
-  window._topoSelect=function(name){
-    if(name===topoSelectedNode)name=null;
-    topoSelectedNode=name;
-    topoBlast=[];
-    if(name)fetchBlastRadius(name);
-    else renderTopology();
-  };
-  window._topoRefresh=function(){fetchTopology()};
-  window._topoViewTraces=function(svc){
-    fetch('/api/services/'+encodeURIComponent(svc)+'/traces?limit=10')
-      .then(function(r){return r.json()}).then(function(data){
-        var msg='Recent traces for '+svc+':\n';
-        (data||[]).forEach(function(t){msg+='\n  '+t.traceID+' ('+t.serviceName+', '+(t.hasError?'ERROR':'OK')+')'});
-        alert(msg||'No traces found');
-      }).catch(function(){alert('Failed to fetch traces')});
-  };
-  window._topoViewLogs=function(svc){
-    fetch('/api/services/'+encodeURIComponent(svc)+'/logs?limit=20')
-      .then(function(r){return r.json()}).then(function(data){
-        var msg='Recent logs for '+svc+':\n';
-        (data||[]).forEach(function(l){msg+='\n  ['+l.severity+'] '+l.body});
-        alert(msg||'No logs found');
-      }).catch(function(){alert('Failed to fetch logs')});
-  };
-  window._topoInvestigate=function(ns,name){
-    if(!confirm('Trigger AI investigation for '+ns+'/'+name+'?'))return;
-    fetch('/api/investigate/'+encodeURIComponent(ns)+'/'+encodeURIComponent(name),{method:'POST'})
-      .then(function(r){
-        if(!r.ok)return r.text().then(function(t){throw new Error(t)});
+async function apiFetch(url, allowFail=false) {
+    try {
+        const r = await fetch(url);
+        if (!r.ok) { if (!allowFail) console.warn('API error', url, r.status); return null; }
         return r.json();
-      }).then(function(data){
-        alert('AI Investigation started for '+ns+'/'+name+'.\nStatus: '+(data.status||'unknown'));
-      }).catch(function(e){alert('Investigation failed: '+e.message)});
-  };
+    } catch(e) { if (!allowFail) console.warn('Fetch failed', url, e.message); return null; }
+}
 
-  /* ── Render ────────────────────────────────── */
-  function render(){
-    renderHeader();renderMetrics();renderNamespaces();renderSeverity();
-    renderAgents();renderRuleEngine();renderToolbar();
-    if(activeTab==='incidents'){renderIncidents();renderDetail()}
-    else if(activeTab==='topology'){renderTopology()}
-    else if(activeTab==='rules'){renderRulesTab()}
-    else if(activeTab==='agents'){renderAgentsTab()}
-    else if(activeTab==='namespaces'){renderNsTab()}
-    renderStatusBar();
-  }
+function showToast(msg) {
+    const el=$('toast'); $('toast-msg').textContent=msg;
+    el.style.bottom='24px'; el.style.opacity='1';
+    clearTimeout(toastTimer);
+    toastTimer=setTimeout(()=>{ el.style.bottom='-80px'; el.style.opacity='0'; },3000);
+}
 
-  function renderHeader(){
-    var el=document.getElementById('header-right');
-    var active=stats.active||0;
-    var p1=incidents.filter(function(i){return i.severity==='P1'&&i.phase!=='Resolved'}).length;
-    var h='';
-    if(p1>0)h+='<span class="header-pill pill-p1">'+pulseDot('var(--red)',5)+' '+p1+' P1</span>';
-    h+='<span class="header-pill pill-active">'+pulseDot('var(--red)',4)+' '+active+' active</span>';
-    h+='<select class="tz-select" id="tz-sel" onchange="window._setTZ(this.value)">';
-    tzOptions.forEach(function(z){
-      var label=z==='Local'?'Local ('+browserTZ+')':z;
-      h+='<option value="'+esc(z)+'"'+(selTZ===z?' selected':'')+'>'+esc(label)+'</option>';
+// ── Polling ────────────────────────────────────────────────────────────────
+async function refreshAll() {
+    const [incs, stats, rules, topo, agents] = await Promise.all([
+        apiFetch('/api/incidents'),
+        apiFetch('/api/stats'),
+        apiFetch('/api/rules', true),
+        apiFetch('/api/topology', true),
+        apiFetch('/api/agents', true),
+    ]);
+
+    if (Array.isArray(incs)) S.incidents = incs;
+    if (stats) S.stats = stats;
+    if (Array.isArray(rules)) S.rules = rules;
+    if (topo) S.topoGraph = topo;
+    if (Array.isArray(agents)) S.agents = agents;
+
+    // Auto-select first service
+    const svcs = getServices();
+    if (svcs.length && !svcs.includes(S.selectedSvc)) S.selectedSvc = svcs[0];
+
+    // Auto-select incident
+    if (!S.selectedIncKey || !S.incidents.find(i=>incKey(i)===S.selectedIncKey)) {
+        const pref = S.incidents.find(i=>i.phase==='Active')||S.incidents.find(i=>i.phase==='Detecting')||S.incidents[0];
+        S.selectedIncKey = pref ? incKey(pref) : null;
+    }
+
+    buildTopoModels();
+    renderAll();
+}
+
+function startPolling() {
+    refreshAll();
+    S.pollTimer = setInterval(refreshAll, POLL_INTERVAL);
+}
+
+// ── Tab switching ──────────────────────────────────────────────────────────
+const TABS = ['topology','incidents','metrics','logs','traces','rules','agents'];
+function switchTab(tab) {
+    S.tab = tab;
+    TABS.forEach(t => {
+        const v=$(`view-${t}`), n=$(`nav-${t}`);
+        if (!v||!n) return;
+        const active = t===tab;
+        v.classList.toggle('hidden', !active);
+        n.classList.toggle('active', active);
     });
-    h+='</select>';
-    h+='<span class="clock" id="clock"></span>';
-    h+='<button class="theme-toggle" onclick="window._toggleTheme()" title="Toggle theme">'+(theme==='dark'?'\u2600':'🌙')+'</button>';
-    el.innerHTML=h;
-  }
+    if (tab==='metrics') populateSvcSelectors(), loadMetrics();
+    if (tab==='logs')    populateSvcSelectors(), loadLogs();
+    if (tab==='traces')  populateSvcSelectors(), loadTraces();
+    if (tab==='agents')  renderAgents();
+    lucide.createIcons();
+}
 
-  function renderMetrics(){
-    var el=document.getElementById('sb-metrics');
-    var items=[
-      {l:'Active',v:stats.active||0,c:'var(--red)'},
-      {l:'Detecting',v:stats.detecting||0,c:'var(--purple)'},
-      {l:'Resolved',v:stats.resolved||0,c:'var(--green)'},
-      {l:'Total',v:incidents.length,c:'var(--text-tertiary)'}
-    ];
-    el.innerHTML=items.map(function(m){
-      return '<div class="metric-card"><div class="metric-card-value" style="color:'+m.c+'">'+m.v+'</div><div class="metric-card-label">'+m.l+'</div></div>';
-    }).join('');
-  }
+// ── Topology ───────────────────────────────────────────────────────────────
+function buildTopoModels(reset=false) {
+    const nodes = S.topoGraph?.nodes||{};
+    const edges = S.topoGraph?.edges||[];
+    const wrap = $('canvas-wrap');
+    const W = wrap?.clientWidth||1200, H = wrap?.clientHeight||600;
+    if (reset) S.nodePositions={};
 
-  function renderNamespaces(){
-    var el=document.getElementById('sb-ns');
-    var ns=stats.namespaces||{};var keys=Object.keys(ns).sort();
-    var all=['all'].concat(keys);
-    el.innerHTML=all.map(function(k){
-      var sel=filters.ns===k;var info=ns[k]||{};var cnt=k!=='all'?(info.active||0):0;
-      var monitored=k!=='all'&&info.monitored;
-      return '<div class="sb-item'+(sel?' active':'')+'" onclick="window._f(\'ns\',\''+esc(k)+'\')">'+
-        (monitored?'<span class="sb-dot" style="background:var(--green)"></span>':
-        (k!=='all'?'<span class="sb-dot" style="background:var(--text-tertiary);opacity:0.3"></span>':''))+
-        '<span style="flex:1">'+esc(k)+'</span>'+
-        (cnt>0?'<span class="sb-badge">'+cnt+'</span>':'')+
-        '</div>';
-    }).join('');
-  }
-
-  function renderSeverity(){
-    var el=document.getElementById('sb-sev');
-    el.innerHTML=['all','P1','P2','P3','P4'].map(function(s){
-      var sel=filters.sev===s;
-      var dot=s!=='all'?'<span class="sb-dot" style="background:'+(SEV_COLORS[s]||'var(--text-tertiary)')+'"></span>':'';
-      return '<div class="sb-item'+(sel?' active':'')+'" onclick="window._f(\'sev\',\''+s+'\')">'+dot+'<span>'+s+'</span></div>';
-    }).join('');
-  }
-
-  function renderAgents(){
-    var el=document.getElementById('sb-agents');
-    var agents=stats.agents||[];
-    if(!agents.length){el.innerHTML='<div style="padding:8px;font-size:11px;color:var(--text-tertiary)">No agents</div>';return}
-    el.innerHTML=agents.map(function(a){
-      var name=typeof a==='string'?a:a.name;
-      var healthy=typeof a==='string'?true:a.healthy!==false;
-      var dot=healthy?pulseDot('var(--green)',5):'<span style="width:5px;height:5px;border-radius:50%;background:var(--red);display:inline-block"></span>';
-      var ns=typeof a!=='string'&&a.watchNamespaces?a.watchNamespaces:[];
-      return '<div class="agent-item">'+dot+'<span class="name">'+esc(name)+'</span>'+
-        '<span class="label">'+(healthy?'OK':'ERR')+'</span></div>'+
-        (ns.length?'<div class="agent-sub">watching: '+ns.map(esc).join(', ')+'</div>':'');
-    }).join('');
-  }
-
-  function renderRuleEngine(){
-    var el=document.getElementById('sb-rules');
-    var count=rules.length;
-    var h='<div style="display:flex;align-items:baseline;justify-content:space-between;padding:4px 8px">'+
-      '<span style="font-size:11px;color:var(--text-secondary)">Loaded CRDs</span>'+
-      '<span style="font-family:var(--font-mono);font-size:18px;font-weight:600;color:var(--accent)">'+count+'</span></div>';
-    if(count>0){
-      var svs={};rules.forEach(function(r){svs[r.firesSeverity]=(svs[r.firesSeverity]||0)+1});
-      Object.keys(svs).sort().forEach(function(s){
-        h+='<div style="padding:2px 8px;font-size:11px;color:var(--text-tertiary)">'+s+': '+svs[s]+' rule'+(svs[s]>1?'s':'')+'</div>';
-      });
-    }
-    el.innerHTML=h;
-  }
-
-  function renderToolbar(){
-    var el=document.getElementById('toolbar');
-    if(activeTab==='topology'){
-      var nodeCount=topoGraph&&topoGraph.nodes?Object.keys(topoGraph.nodes).length:0;
-      var edgeCount=topoGraph&&topoGraph.edges?topoGraph.edges.length:0;
-      el.innerHTML='<span class="filter-label">Service Topology</span><span class="toolbar-spacer"></span>'+
-        '<span class="toolbar-meta">'+nodeCount+' services \u00b7 '+edgeCount+' edges</span>'+
-        '<span class="toolbar-kbd">scroll to zoom \u00b7 drag to pan \u00b7 click node for details</span>';
-      return;
-    }
-    var types={};incidents.forEach(function(i){if(i.incidentType)types[i.incidentType]=true});
-    var typeList=Object.keys(types);var f=getFiltered();
-    var h='<div class="filter-group"><span class="filter-label">Phase</span>';
-    h+='<select class="filter-select" onchange="window._f(\'phase\',this.value)">';
-    ['all','Active','Detecting','Resolved'].forEach(function(p){
-      h+='<option value="'+p+'"'+(filters.phase===p?' selected':'')+'>'+p+'</option>';
-    });
-    h+='</select></div>';
-    if(typeList.length>0){
-      h+='<div class="filter-group"><span class="filter-label">Type</span>';
-      h+='<select class="filter-select" onchange="window._f(\'type\',this.value)">';
-      h+='<option value="all"'+(filters.type==='all'?' selected':'')+'>all</option>';
-      typeList.sort().forEach(function(t){h+='<option value="'+esc(t)+'"'+(filters.type===t?' selected':'')+'>'+esc(t)+'</option>'});
-      h+='</select></div>';
-    }
-    h+='<span class="toolbar-spacer"></span>';
-    h+='<span class="toolbar-meta">'+f.length+' result'+(f.length!==1?'s':'')+'</span>';
-    h+='<span class="toolbar-kbd">j/k navigate \u00b7 esc close</span>';
-    el.innerHTML=h;
-  }
-
-  function renderIncidents(){
-    var el=document.getElementById('list-pane');
-    var list=getSorted(getFiltered());
-    var hasSel=!!selectedKey;
-    el.className='list-pane '+(hasSel?'compact':'full');
-    var h='';
-    if(!hasSel){
-      h+='<div class="list-header"><span style="width:22px">#</span><span style="width:36px">Sev</span>'+
-        '<span style="flex:2">Service</span><span style="width:100px">Namespace</span>'+
-        '<span style="width:90px">Phase</span><span style="width:80px;text-align:right">Started</span></div>';
-    }
-    if(!list.length){
-      h+='<div class="empty-state"><div class="empty-state-title">No incidents match</div>'+
-        '<div class="empty-state-sub">Adjust filters or wait for new events</div></div>';
-    } else {
-      list.forEach(function(inc,idx){
-        var key=incKey(inc);var isSel=key===selectedKey;var isRes=inc.phase==='Resolved';
-        var sev=inc.severity||'P4';
-        h+='<div class="inc-row'+(hasSel?' compact':'')+(isSel?' selected':'')+(isRes?' resolved':'')+'" onclick="window._sel(\''+esc(key)+'\')">';
-        if(!hasSel)h+='<span class="inc-num">'+pad(idx+1)+'</span>';
-        h+='<span class="sev '+(hasSel?'sm':'md')+' sev-'+sev+'">'+sev+'</span>';
-        h+='<div class="inc-info"><div class="inc-name'+(hasSel?' compact':'')+'">'+esc(dname(inc))+'</div>';
-        h+='<div class="inc-meta">'+(hasSel?esc(inc.incidentType):esc(inc.namespace)+' \u00b7 '+esc(inc.incidentType))+'</div></div>';
-        if(!hasSel)h+='<span class="inc-ns">'+esc(inc.namespace)+'</span>';
-        h+='<span class="phase phase-'+(inc.phase||'Resolved')+'">';
-        if(inc.phase==='Active'||inc.phase==='Detecting')h+=pulseDot(inc.phase==='Active'?'var(--red)':'var(--purple)',5);
-        h+=esc(inc.phase)+'</span>';
-        if(!hasSel){
-          h+='<div class="inc-time"><div class="inc-time-rel">'+relTime(startTime(inc))+'</div>';
-          h+='<div class="inc-time-abs">'+absTime(startTime(inc))+'</div></div>';
+    S.nodesData = Object.keys(nodes).map((name, idx) => {
+        const src = nodes[name]||{};
+        const metrics = src.metrics||{};
+        const incidents = Array.isArray(src.incidents)?src.incidents:[];
+        const cpuPct = clamp(num(metrics.cpuUsage)*20, 0, 100);
+        const memPct = clamp(num(metrics.memoryUsage)/(4*1024*1024*1024)*100, 0, 100);
+        if (!S.nodePositions[name]) {
+            const pre = NODE_LAYOUT[name];
+            if (pre) { S.nodePositions[name]={x:W*pre.x/100, y:H*pre.y/100}; }
+            else { const r=Math.floor(idx/4), c=idx%4; S.nodePositions[name]={x:W*(c+1)/5, y:H*(r+1)/4}; }
         }
-        h+='</div>';
-      });
-    }
-    el.innerHTML=h;
-  }
-
-  function renderDetail(){
-    var p=document.getElementById('detail-panel');
-    if(!selectedKey){p.style.display='none';return}
-    var inc=incidents.find(function(i){return incKey(i)===selectedKey});
-    if(!inc){p.style.display='none';selectedKey=null;return}
-    p.style.display='';
-    var sev=inc.severity||'P4';var name=dname(inc);
-    var podRes=findRes(inc,'Pod');var nodeRes=findRes(inc,'Node');var ref=primaryRef(inc);
-    var h='';
-
-    /* Header */
-    h+='<div class="detail-head" style="position:relative">';
-    h+='<div class="detail-badges">';
-    h+='<span class="sev md sev-'+sev+'">'+sev+'</span>';
-    h+='<span class="phase phase-'+(inc.phase||'Resolved')+'">';
-    if(inc.phase==='Active'||inc.phase==='Detecting')h+=pulseDot(inc.phase==='Active'?'var(--red)':'var(--purple)',5);
-    h+=esc(inc.phase)+'</span>';
-    h+='<span class="tag tag-default">'+esc(inc.incidentType)+'</span>';
-    h+=(inc.notified?'<span class="tag tag-green">notified</span>':'<span class="tag tag-purple">pending</span>');
-    h+='</div>';
-    h+='<div class="detail-title">'+esc(name)+'</div>';
-    h+='<div class="detail-subtitle"><span class="val">'+esc(inc.namespace)+'</span><span class="sep">\u00b7</span>';
-    h+='<span class="val">'+esc(inc.agentRef)+'</span><span class="sep">\u00b7</span>';
-    h+='<span>started </span><span class="val">'+absTime(startTime(inc))+'</span>';
-    if(resolvedTime(inc))h+=' \u2192 <span style="color:var(--green)">'+absTime(resolvedTime(inc))+'</span>';
-    h+='</div>';
-    h+='<div class="detail-dur"><span class="detail-dur-label">Duration</span><span class="detail-dur-val" id="live-dur">';
-    if(inc.phase==='Resolved')h+='<span style="color:var(--text-secondary)">'+finDur(startTime(inc),resolvedTime(inc))+'</span>';
-    else h+='<span style="color:'+(inc.phase==='Active'?'var(--amber)':'var(--purple)')+'">'+liveDur(startTime(inc))+'</span>';
-    h+='</span></div>';
-    h+='<div class="detail-id">IncidentReport \u00b7 '+esc(inc.namespace)+'/'+esc(inc.name)+'</div>';
-    h+='<button class="detail-close" onclick="window._close()">\u00d7</button>';
-    h+='</div>';
-
-    /* Body */
-    h+='<div class="detail-body">';
-
-    /* Timeline */
-    var tl=inc.timeline||[];
-    h+='<div><div class="section-title">Timeline</div>';
-    if(tl.length){
-      h+='<div class="timeline"><div class="tl-track"><div class="tl-line"></div>';
-      tl.forEach(function(ev,i){
-        var cls='tl-dot';if(i===0)cls+=' first';else if(i===tl.length-1&&inc.phase==='Resolved')cls+=' last-resolved';
-        h+='<div class="tl-entry"><div class="'+cls+'"></div>';
-        h+='<div class="tl-time">'+absTime(ev.time)+'<span class="rel">'+relTime(ev.time)+'</span></div>';
-        h+='<div class="tl-event">'+esc(ev.event)+'</div></div>';
-      });
-      h+='</div></div>';
-    } else h+='<div style="font-size:12px;color:var(--text-tertiary)">No timeline entries</div>';
-    h+='</div>';
-
-    /* Signals */
-    var sigs=inc.correlatedSignals||[];
-    var sigGroups=[];var sigMap={};
-    sigs.forEach(function(s){if(sigMap[s]!==undefined)sigGroups[sigMap[s]].count++;else{sigMap[s]=sigGroups.length;sigGroups.push({text:s,count:1})}});
-    sigGroups.sort(function(a,b){return b.count-a.count});
-
-    h+='<div><div class="section-title-toggle" onclick="window._toggleSignals()">';
-    h+='<span>Correlated Signals ('+sigs.length+(sigGroups.length!==sigs.length?' \u00b7 '+sigGroups.length+' unique':'')+')</span>';
-    h+='<span class="toggle-icon'+(signalsOpen?'':' collapsed')+'">\u25BE</span></div>';
-    h+='<div id="signals-body" style="'+(signalsOpen?'':'display:none')+'">';
-    if(sigGroups.length){
-      sigGroups.forEach(function(g,i){
-        h+='<div class="card"><span class="signal-num">'+(i+1)+'.</span>';
-        h+='<span class="signal-dot" style="background:'+(SEV_COLORS[sev]||'var(--text-tertiary)')+'"></span>';
-        h+='<span class="signal-text">'+esc(g.text)+'</span>';
-        if(g.count>1)h+='<span class="signal-count">\u00d7'+g.count+'</span>';
-        h+='</div>';
-      });
-    } else h+='<div style="font-size:12px;color:var(--text-tertiary)">No signals</div>';
-    h+='</div></div>';
-
-    /* Resources */
-    var res=inc.affectedResources||[];
-    h+='<div><div class="section-title">Affected Resources</div>';
-    if(res.length){
-      res.forEach(function(r){
-        h+='<div class="card"><span class="res-kind">'+esc((r.kind||'').toUpperCase())+'</span>';
-        h+='<div style="flex:1;min-width:0"><div class="res-name">'+esc(r.name)+'</div>';
-        if(r.namespace)h+='<div class="res-ns">'+esc(r.namespace)+'</div>';
-        h+='</div><button class="copy-btn" onclick="window._copy(this,\''+esc(r.name)+'\')">copy</button></div>';
-      });
-    } else h+='<div style="font-size:12px;color:var(--text-tertiary)">None</div>';
-    h+='</div>';
-
-    /* Commands */
-    var allCmds=[];var cmdSeen={};
-    function addCmd(label,cmd){if(cmdSeen[cmd])return;cmdSeen[cmd]=true;allCmds.push({k:label,v:cmd})}
-    addCmd('get','kubectl get incidentreport -n '+inc.namespace+' | grep '+name);
-    addCmd('describe','kubectl describe incidentreport '+inc.name+' -n '+inc.namespace);
-    if(podRes)addCmd('logs','kubectl logs '+podRes.name+' -n '+inc.namespace+' --previous');
-    addCmd('events','kubectl get events -n '+inc.namespace+' --sort-by=\'.lastTimestamp\' | head -30');
-    var pb=PLAYBOOK[inc.incidentType]||[];
-    pb.forEach(function(cmd){
-      var filled=cmd.replace(/<ns>/g,inc.namespace).replace(/<name>/g,(ref&&ref.name)||name)
-        .replace(/<pod-name>/g,podRes?podRes.name:name).replace(/<pod>/g,podRes?podRes.name:name)
-        .replace(/<node-name>/g,nodeRes?nodeRes.name:name);
-      addCmd('action',filled);
+        const {x,y}=S.nodePositions[name];
+        return { id:name, label:name, kind:src.kind||'Service', status:src.status||'unknown',
+                 icon:chooseIcon(src.icon,src.kind,name), x, y,
+                 cpu:cpuPct, mem:memPct, metrics, incidents,
+                 rca: incidents.length>0?(incidents[0].summary||`${incidents[0].incidentType||'Issue'} detected`):'',
+                 replicas: src.replicas||null };
     });
-    h+='<div><div class="section-title">Commands'+(pb.length?' \u00b7 '+esc(inc.incidentType):'')+'</div>';
-    allCmds.forEach(function(c,i){
-      h+='<div class="card"><span class="cmd-num">'+(i+1)+'.</span>';
-      h+='<code class="cmd-code'+(c.k==='action'?' muted':'')+'">'+esc(c.v)+'</code>';
-      h+='<button class="copy-btn" onclick="window._copy(this,\''+esc(c.v.replace(/'/g,"\\'"))+'\')">copy</button></div>';
-    });
-    h+='</div>';
 
-    /* Notifications */
-    h+='<div><div class="section-title">Notifications</div>';
-    [{ch:'Slack',dest:'#incidents',ok:inc.notified},
-     {ch:'PagerDuty',dest:'P1/P2 only',ok:inc.notified&&(sev==='P1'||sev==='P2')},
-     {ch:'K8s Event',dest:'IncidentReport',ok:true}
-    ].forEach(function(n){
-      h+='<div class="card" style="justify-content:space-between"><div style="display:flex;align-items:center;gap:10px">';
-      h+='<span class="notif-ch">'+esc(n.ch)+'</span><span class="notif-dest">'+esc(n.dest)+'</span></div>';
-      h+='<span class="notif-status '+(n.ok?'notif-ok':'notif-skip')+'">'+(n.ok?'SENT':'SKIPPED')+'</span></div>';
-    });
-    h+='</div>';
+    S.edgesData = edges.map(e=>({ source:e.source||e.from, target:e.target||e.to, status:e.status||'active' }));
+    if (S.selectedNode && !S.nodesData.find(n=>n.id===S.selectedNode)) S.selectedNode=null;
+}
 
-    /* Trace & Rule */
-    var traceId=inc.traceId||'';var firedRule=inc.firedRule||'';
-    if(traceId||firedRule){
-      h+='<div><div class="section-title">Trace & Rule Engine</div>';
-      if(firedRule)h+='<div class="card"><span class="cmd-num">rule</span><code class="cmd-code">'+esc(firedRule)+'</code></div>';
-      if(traceId)h+='<div class="card"><span class="cmd-num">trace</span><code class="cmd-code">'+esc(traceId)+'</code><button class="copy-btn" onclick="window._copy(this,\''+esc(traceId)+'\')">copy</button></div>';
-      h+='</div>';
+function resetLayout() { buildTopoModels(true); renderTopology(); }
+
+function renderTopology() {
+    renderNodes(); renderEdges();
+    if (S.selectedNode) openTopoPanel(S.selectedNode);
+}
+
+function renderEdges() {
+    const svg=$('svg-edges'); if (!svg) return;
+    const byId={}; S.nodesData.forEach(n=>byId[n.id]=n);
+    svg.innerHTML = S.edgesData.map(e=>{
+        const a=byId[e.source], b=byId[e.target]; if (!a||!b) return '';
+        const dx=b.x-a.x;
+        const d=`M ${a.x} ${a.y} C ${a.x+dx/2} ${a.y}, ${b.x-dx/2} ${b.y}, ${b.x} ${b.y}`;
+        return `<path d="${d}" class="edge-path ${esc(e.status)}"/>`;
+    }).join('');
+}
+
+function renderNodes() {
+    const layer=$('div-nodes'); if (!layer) return;
+    layer.innerHTML = S.nodesData.map(n=>{
+        const sel = S.selectedNode===n.id ? 'selected' : '';
+        const ic = n.status==='healthy'?'text-emerald-400':n.status==='warning'?'text-amber-400':n.status==='critical'?'text-red-400':'text-slate-400';
+        const dot = n.status==='critical'?'bg-red-500 pulse-dot':n.status==='warning'?'bg-amber-500':'';
+        const enc = encodeURIComponent(n.id);
+        return `<div id="nd-${enc}" class="topo-node ${sel}" style="left:${n.x}px;top:${n.y}px"
+            onmousedown="startDrag(event,decodeURIComponent('${enc}'))"
+            onclick="selectNode(decodeURIComponent('${enc}'),event)">
+            <div class="node-ring w-12 h-12 rounded-full border-2 border-slate-700 bg-[#0a1628] flex items-center justify-center shadow-lg relative transition-all">
+                <i data-lucide="${esc(n.icon)}" class="w-5 h-5 ${ic}"></i>
+                ${dot?`<div class="absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-[#020817] ${dot}"></div>`:''}
+            </div>
+            <div class="absolute top-full mt-2 left-1/2 -translate-x-1/2 pointer-events-none">
+                <div class="text-[10px] font-medium text-slate-300 bg-[#0a1628]/90 px-2 py-0.5 rounded border border-slate-800/60 whitespace-nowrap shadow">${esc(n.label)}</div>
+            </div>
+        </div>`;
+    }).join('');
+    lucide.createIcons();
+}
+
+// drag
+function startDrag(e, nodeId) {
+    dragNode=nodeId; isDragging=false;
+    const el=document.getElementById(`nd-${encodeURIComponent(nodeId)}`);
+    if (!el) return;
+    dragOX=e.clientX-S.nodePositions[nodeId].x;
+    dragOY=e.clientY-S.nodePositions[nodeId].y;
+    e.preventDefault();
+}
+document.addEventListener('mousemove', e=>{
+    if (!dragNode) return; isDragging=true;
+    const wrap=$('canvas-wrap'); if (!wrap) return;
+    const rect=wrap.getBoundingClientRect();
+    const x=clamp(e.clientX-dragOX,20,rect.width-20);
+    const y=clamp(e.clientY-dragOY,20,rect.height-20);
+    S.nodePositions[dragNode]={x,y};
+    const el=document.getElementById(`nd-${encodeURIComponent(dragNode)}`);
+    if (el) { el.style.left=x+'px'; el.style.top=y+'px'; }
+    // update node
+    const nd=S.nodesData.find(n=>n.id===dragNode);
+    if (nd) { nd.x=x; nd.y=y; }
+    renderEdges();
+});
+document.addEventListener('mouseup', ()=>{ dragNode=null; isDragging=false; });
+
+function selectNode(id, e) {
+    if (isDragging) return;
+    S.selectedNode = id;
+    // update selected class
+    document.querySelectorAll('.topo-node').forEach(el=>el.classList.remove('selected'));
+    const el=document.getElementById(`nd-${encodeURIComponent(id)}`);
+    if (el) el.classList.add('selected');
+    openTopoPanel(id);
+}
+
+async function openTopoPanel(id) {
+    const node = S.nodesData.find(n=>n.id===id);
+    if (!node) return;
+    const panel=$('topo-panel');
+    panel.classList.remove('closed'); panel.classList.add('open');
+    $('tp-title').textContent = node.label;
+    $('tp-kind').textContent = node.kind;
+    $('tp-icon').setAttribute('data-lucide', node.icon);
+
+    // Anomaly
+    const anomalyBox=$('tp-anomaly');
+    if (node.rca) {
+        anomalyBox.classList.remove('hidden');
+        $('tp-anomaly-text').textContent = node.rca;
+    } else { anomalyBox.classList.add('hidden'); }
+
+    // Replicas
+    const repEl=$('tp-replicas');
+    if (node.replicas) {
+        const cur=node.replicas.current, des=node.replicas.desired;
+        const cls=cur<des?'text-red-400 font-bold':'text-emerald-400 font-bold';
+        repEl.innerHTML=`${des} Desired / <span class="${cls}">${cur} Current</span>`;
+    } else { repEl.textContent='—'; }
+
+    $('tp-restarts').textContent = node.incidents.length;
+
+    // Load metrics
+    const metrics = await apiFetch(`/api/services/${encodeURIComponent(id)}/metrics`, true);
+    const m = metrics||node.metrics||{};
+    const cpuPct = clamp(num(m.cpuUsage)*20,0,100);
+    const memPct = clamp(num(m.memoryUsage)/(4*1024*1024*1024)*100,0,100);
+    $('tp-cpu-val').textContent=`${Math.round(cpuPct)}%`;
+    $('tp-mem-val').textContent=`${Math.round(memPct)}%`;
+    renderSparkBars('tp-cpu-bars', cpuPct, 'bg-blue-500');
+    renderSparkBars('tp-mem-bars', memPct, memPct>80?'bg-red-500':'bg-purple-500');
+
+    const rps = m.requestRate != null ? `${num(m.requestRate,0).toFixed(1)}/s` : '—';
+    $('tp-rps').textContent=rps;
+
+    const tracesBtn=$('tp-traces-btn');
+    tracesBtn.classList.toggle('hidden', S.tab!=='topology');
+    if (S.tab==='topology') {
+        tracesBtn.onclick=()=>{ S.selectedSvc=id; switchTab('traces'); };
+        tracesBtn.classList.remove('hidden');
     }
 
-    /* Evidence */
-    h+='<div><div class="section-title">Evidence Summary</div>';
-    h+='<div class="evidence-card"><div class="evidence-label"><span class="evidence-dot"></span>';
-    h+='<span class="evidence-tag">Rule-Based Incident View</span></div>';
-    var body=inc.summary||inc.message||(inc.correlatedSignals&&inc.correlatedSignals.length?inc.correlatedSignals[0]:'Phase 1 records signals, affected resources, and timeline for quick investigation.');
-    h+='<div class="evidence-body">'+esc(body)+'</div></div></div>';
+    lucide.createIcons();
+}
+function closeTopoPanel() {
+    const p=$('topo-panel'); p.classList.remove('open'); p.classList.add('closed');
+    S.selectedNode=null;
+    document.querySelectorAll('.topo-node').forEach(el=>el.classList.remove('selected'));
+}
 
-    /* AI RCA */
-    if(inc.rca){
-      h+='<div><div class="section-title">\u{1F916} AI Root Cause Analysis</div>';
-      h+='<div class="evidence-card" style="border-left:3px solid var(--accent)">';
-      h+='<div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:6px">'+esc(inc.rca.rootCause)+'</div>';
-      if(inc.rca.confidence)h+='<div style="font-size:11px;color:var(--text-tertiary);margin-bottom:8px">Confidence: '+esc(inc.rca.confidence)+' \u00b7 '+(inc.rca.investigatedAt?absTime(inc.rca.investigatedAt):'')+'</div>';
-      if(inc.rca.evidence&&inc.rca.evidence.length){
-        h+='<div style="font-size:11px;font-weight:600;color:var(--text-secondary);margin:6px 0 4px">Evidence</div>';
-        inc.rca.evidence.forEach(function(e){h+='<div class="card" style="font-size:11px">'+esc(e)+'</div>'});
-      }
-      if(inc.rca.playbook&&inc.rca.playbook.length){
-        h+='<div style="font-size:11px;font-weight:600;color:var(--text-secondary);margin:6px 0 4px">Playbook</div>';
-        inc.rca.playbook.forEach(function(cmd,i){
-          h+='<div class="card"><span class="cmd-num">'+(i+1)+'.</span><code class="cmd-code">'+esc(cmd)+'</code>';
-          h+='<button class="copy-btn" onclick="window._copy(this,\''+esc(cmd.replace(/'/g,"\\'"))+'\')">copy</button></div>';
+function renderSparkBars(containerId, pct, colorClass) {
+    const el=$(containerId); if (!el) return;
+    const vals=[0.5,0.65,0.75,0.85,1].map(m=>clamp(Math.round(pct*m),3,100));
+    el.innerHTML=vals.map(v=>`<div class="spark-bar flex-1 ${colorClass}" style="height:${v}%"></div>`).join('');
+}
+
+// ── Incidents ──────────────────────────────────────────────────────────────
+function setIncPhase(p) {
+    S.incPhaseFilter=p;
+    ['all','active','detecting','resolved'].forEach(id=>{
+        const el=$(`ifil-${id}`); if (!el) return;
+        const active=(p===''&&id==='all')||(p.toLowerCase()===id);
+        el.className=active
+            ?'px-2 py-0.5 rounded text-[10px] font-bold bg-indigo-500/15 text-indigo-400 border border-indigo-500/30 transition-colors'
+            :'px-2 py-0.5 rounded text-[10px] font-bold bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600 transition-colors';
+    });
+    renderIncidentsList();
+}
+function filterIncidents() { S.incQuery=$('inc-search').value.toLowerCase(); renderIncidentsList(); }
+
+function filteredIncidents() {
+    return S.incidents.filter(i=>{
+        if (S.incPhaseFilter && i.phase!==S.incPhaseFilter) return false;
+        if (S.incQuery) {
+            const hay=[i.name,i.namespace,i.incidentType,i.summary,i.podName,serviceFor(i)].join(' ').toLowerCase();
+            if (!hay.includes(S.incQuery)) return false;
+        }
+        return true;
+    }).sort((a,b)=>sevRank(b.severity)-sevRank(a.severity)||new Date(incStart(b))-new Date(incStart(a)));
+}
+
+function renderIncidentsList() {
+    const list=$('inc-list'); if (!list) return;
+    const items=filteredIncidents();
+    $('inc-total').textContent=`${S.incidents.length} Total`;
+
+    const active=S.incidents.filter(i=>i.phase==='Active'||i.phase==='Detecting').length;
+    $('inc-badge').classList.toggle('hidden', active===0);
+
+    if (!items.length) {
+        list.innerHTML=`<div class="p-6 text-xs text-slate-600">No incidents match your filter.</div>`;
+        return;
+    }
+    list.innerHTML=items.map(inc=>{
+        const k=incKey(inc), sel=S.selectedIncKey===k;
+        const sbc=SEV_BADGE[inc.severity]||SEV_BADGE.P4;
+        const phc=PHASE_BADGE[inc.phase]||PHASE_BADGE.Resolved;
+        return `<div class="inc-row p-3 border-b border-slate-800/40 cursor-pointer ${sel?'sel':''}" onclick="selectInc('${esc(k)}')">
+            <div class="flex justify-between items-center mb-1">
+                <div class="flex items-center gap-1.5 min-w-0">
+                    <span class="px-1.5 py-0.5 rounded text-[9px] font-bold font-mono border ${sbc}">${esc(inc.severity||'P4')}</span>
+                    <span class="font-semibold text-slate-200 text-xs truncate">${esc(serviceFor(inc))}</span>
+                </div>
+                <span class="text-[10px] text-slate-600 font-mono shrink-0 ml-1">${esc(relTime(incStart(inc)))}</span>
+            </div>
+            <div class="flex justify-between items-center">
+                <span class="text-[10px] text-slate-500 font-mono truncate">${esc(inc.incidentType||'Unknown')}</span>
+                <span class="px-1.5 py-0.5 rounded border text-[9px] font-bold shrink-0 ml-1 ${phc}">${esc(inc.phase||'Resolved')}</span>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function selectInc(key) {
+    S.selectedIncKey=key;
+    renderIncidentsList();
+    renderIncidentDetail();
+    loadIncidentExtras(key);
+}
+
+async function loadIncidentExtras(key) {
+    const inc=S.incidents.find(i=>incKey(i)===key); if (!inc) return;
+    // Load full detail (trace, firedRule)
+    const detail=await apiFetch(`/api/incidents/${encodeURIComponent(inc.namespace)}/${encodeURIComponent(inc.name)}`, true);
+    if (detail) { Object.assign(inc, detail); }
+    // Load timeline
+    if (inc.fingerprint) {
+        const tl=await apiFetch(`/api/timeline?fingerprint=${encodeURIComponent(inc.fingerprint)}`, true);
+        if (Array.isArray(tl)) inc._timeline=tl;
+    }
+    if (S.selectedIncKey===key) renderIncidentDetail();
+}
+
+function renderIncidentDetail() {
+    const det=$('inc-detail'), emp=$('inc-empty'); if (!det||!emp) return;
+    const inc=S.incidents.find(i=>incKey(i)===S.selectedIncKey);
+    if (!inc) { det.classList.add('hidden'); emp.classList.remove('hidden'); return; }
+    emp.classList.add('hidden'); det.classList.remove('hidden');
+
+    const svc=serviceFor(inc);
+    const sbc=SEV_BADGE[inc.severity]||SEV_BADGE.P4;
+    const phc=PHASE_BADGE[inc.phase]||PHASE_BADGE.Resolved;
+
+    $('id-title').textContent=svc;
+    $('id-type').textContent=inc.incidentType||'Unknown';
+    $('id-meta').textContent=`${inc.namespace} • ${inc.name}`;
+    $('id-sev').className=`px-2 py-0.5 rounded text-[10px] font-bold font-mono border ${sbc}`;
+    $('id-sev').textContent=inc.severity||'P4';
+    $('id-phase').className=`px-2 py-0.5 rounded text-[10px] font-bold font-mono flex items-center gap-1.5 border ${phc}`;
+    $('id-phase').innerHTML=(inc.phase==='Active'?'<div class="w-1.5 h-1.5 bg-red-500 rounded-full pulse-dot"></div>':'<i data-lucide="check" class="w-2.5 h-2.5"></i>')+` ${esc(inc.phase||'Resolved')}`;
+    $('id-elapsed').textContent=elapsed(incStart(inc), inc.resolvedAt);
+
+    const summary=(inc.rca?.rootCause)||inc.summary||inc.message||'No summary available.';
+    $('id-summary').textContent=summary;
+
+    // Playbook
+    const cmds=buildPlaybook(inc);
+    $('id-playbook').innerHTML=cmds.length
+        ? cmds.map((cmd,i)=>`<div class="flex items-center gap-2 bg-[#060d1a] p-2 rounded-lg border border-slate-800/60">
+            <span class="text-slate-600 font-mono text-[9px] w-4 shrink-0">${i+1}.</span>
+            <code class="text-indigo-300 font-mono text-[10px] flex-grow truncate">${esc(cmd)}</code>
+            <button onclick="copyCmd(this)" class="shrink-0 bg-slate-800 hover:bg-slate-700 text-slate-400 px-1.5 py-0.5 rounded text-[9px] transition-colors"><i data-lucide="copy" class="w-3 h-3"></i></button>
+        </div>`).join('')
+        +((!inc.rca&&(inc.phase==='Active'||inc.phase==='Detecting'))?`<button onclick="triggerRCA('${esc(inc.namespace)}','${esc(inc.name)}')" class="mt-2 w-full bg-indigo-600 hover:bg-indigo-500 text-white text-xs font-semibold py-2 rounded-lg transition-colors flex items-center justify-center gap-1.5"><i data-lucide="sparkles" class="w-3.5 h-3.5"></i> Run AI Investigation</button>`:'')
+        : `<div class="text-xs text-slate-600 p-2">No playbook commands available.</div>`;
+
+    // Resources
+    const res=Array.isArray(inc.affectedResources)?inc.affectedResources:[];
+    $('id-resources').innerHTML=res.length
+        ? res.map(r=>`<div class="bg-slate-900/60 border border-slate-800/60 rounded-lg p-2 flex items-center justify-between gap-2">
+            <div class="flex items-center gap-2">
+                <span class="bg-indigo-500/10 text-indigo-400 font-mono text-[9px] px-1.5 py-0.5 rounded border border-indigo-500/20 font-bold uppercase">${esc(r.kind||'Resource')}</span>
+                <span class="text-xs text-slate-300">${esc(r.name||'unknown')}</span>
+            </div>
+            <span class="text-[10px] text-slate-500 font-mono">${esc(r.namespace||inc.namespace)}</span>
+        </div>`).join('')
+        : `<div class="text-xs text-slate-600">No affected resources reported.</div>`;
+
+    // Blast radius + related traces
+    let extra='';
+    if (Array.isArray(inc.blastRadius)&&inc.blastRadius.length) {
+        extra+=`<div class="mt-2"><div class="text-[10px] uppercase text-slate-600 mb-1">Blast Radius</div><div class="flex flex-wrap gap-1">${inc.blastRadius.map(s=>`<span class="px-2 py-0.5 rounded bg-red-500/10 border border-red-500/20 text-[10px] font-mono text-red-300">${esc(s)}</span>`).join('')}</div></div>`;
+    }
+    if (inc.traceId) {
+        extra+=`<div class="mt-2"><span class="text-[10px] text-slate-600">Trace: </span><button onclick="viewTrace('${esc(inc.traceId)}')" class="text-[10px] font-mono text-indigo-400 hover:text-indigo-300 underline">${esc(inc.traceId.slice(0,16))}…</button></div>`;
+    }
+    $('id-resources').innerHTML+=extra;
+
+    // Conditions
+    const notified=inc.notified?`<div class="p-2.5 flex items-start gap-2"><i data-lucide="bell-ring" class="w-3.5 h-3.5 text-emerald-500 mt-0.5"></i><div class="text-xs font-semibold text-slate-200">Alert Dispatched <span class="font-mono text-[9px] bg-slate-800 px-1 rounded text-slate-400 ml-1">True</span></div></div>`:'';
+    const signalCount=inc.signalCount>0?`<div class="p-2.5 flex items-start gap-2"><i data-lucide="signal" class="w-3.5 h-3.5 text-blue-500 mt-0.5"></i><div class="text-xs font-semibold text-slate-200">Signals <span class="font-mono text-[9px] bg-slate-800 px-1 rounded text-slate-400 ml-1">${inc.signalCount}</span></div></div>`:'';
+    $('id-conditions').innerHTML=`
+        <div class="p-2.5 border-b border-slate-800/40 flex items-start gap-2"><i data-lucide="check-circle" class="w-3.5 h-3.5 text-emerald-500 mt-0.5"></i><div class="text-xs font-semibold text-slate-200">Signals Correlated <span class="font-mono text-[9px] bg-slate-800 px-1 rounded text-slate-400 ml-1">${(inc.correlatedSignals||[]).length>0?'True':'False'}</span></div></div>
+        ${notified}${signalCount}`;
+
+    // Correlated signals
+    const sigs=Array.isArray(inc.correlatedSignals)?inc.correlatedSignals:[];
+    const sigSec=$('id-signals-section');
+    sigSec.classList.toggle('hidden', sigs.length===0);
+    if (sigs.length) { $('id-signals').innerHTML=sigs.map(s=>`<span class="px-2 py-0.5 rounded bg-blue-500/10 border border-blue-500/20 text-[10px] font-mono text-blue-300">${esc(s)}</span>`).join(''); }
+
+    // Timeline
+    const tl=Array.isArray(inc._timeline)?inc._timeline:[];
+    const tlSec=$('id-timeline-section');
+    tlSec.classList.toggle('hidden', tl.length===0);
+    if (tl.length) {
+        $('id-timeline').innerHTML=tl.slice(-20).map(e=>{
+            const cls=e.phase==='Active'?'text-red-400':e.phase==='Resolved'?'text-emerald-400':'text-purple-400';
+            return `<div class="flex items-start gap-2 py-1.5 border-b border-slate-800/30">
+                <span class="font-mono text-[10px] text-slate-600 shrink-0 mt-0.5">${esc(fmtTime(e.time))}</span>
+                <span class="w-1.5 h-1.5 rounded-full mt-1.5 shrink-0 ${cls.replace('text','bg')}"></span>
+                <span class="text-[11px] text-slate-400">${esc(e.event)}</span>
+                <span class="ml-auto text-[9px] font-mono ${cls} shrink-0">${esc(e.phase||'')}</span>
+            </div>`;
+        }).join('');
+    }
+
+    // RCA
+    const rcaSec=$('id-rca-section');
+    if (inc.rca?.rootCause) {
+        rcaSec.classList.remove('hidden');
+        $('id-rca-cause').textContent=inc.rca.rootCause;
+        $('id-rca-confidence').textContent=inc.rca.confidence?`Confidence: ${inc.rca.confidence}`:'';
+    } else { rcaSec.classList.add('hidden'); }
+
+    lucide.createIcons();
+}
+
+function buildPlaybook(inc) {
+    const svc=serviceFor(inc), ns=inc.namespace, pod=inc.podName||svc;
+    const cmds=new Set();
+    cmds.add(`kubectl describe incidentreport ${inc.name} -n ${ns}`);
+    cmds.add(`kubectl get events -n ${ns} --sort-by='.lastTimestamp' | head -30`);
+    if (inc.rca?.playbook) inc.rca.playbook.forEach(c=>cmds.add(c));
+    (PLAYBOOK_DB[inc.incidentType]||[]).forEach(t=>cmds.add(t.replace(/<ns>/g,ns).replace(/<name>/g,svc).replace(/<pod>/g,pod).replace(/<node>/g,svc)));
+    return [...cmds];
+}
+
+function copyCmd(btn) {
+    const code=btn.closest('div').querySelector('code');
+    if (code) navigator.clipboard?.writeText(code.textContent).then(()=>showToast('Copied to clipboard'));
+}
+
+async function triggerRCA(ns, name) {
+    showToast('Starting AI investigation…');
+    const r=await apiFetch(`/api/investigate/${encodeURIComponent(ns)}/${encodeURIComponent(name)}`, true);
+    if (r) showToast('AI investigation started');
+}
+
+function viewTrace(tid) { S.selectedSvc=''; switchTab('traces'); }
+
+// ── Metrics ────────────────────────────────────────────────────────────────
+function populateSvcSelectors() {
+    const svcs=getServices();
+    ['metrics-svc','logs-svc','traces-svc'].forEach(selId=>{
+        const sel=$(selId); if (!sel) return;
+        const cur=sel.value||S.selectedSvc;
+        sel.innerHTML=svcs.length
+            ? svcs.map(s=>`<option value="${esc(s)}" ${s===cur?'selected':''}>${esc(s)}</option>`).join('')
+            : '<option value="">No services</option>';
+        if (!S.selectedSvc && svcs.length) S.selectedSvc=svcs[0];
+    });
+}
+
+function onMetricsSvcChange() { S.selectedSvc=$('metrics-svc').value; loadMetrics(); }
+
+async function loadMetrics() {
+    const svc=$('metrics-svc')?.value||S.selectedSvc; if (!svc) return;
+    const data=await apiFetch(`/api/services/${encodeURIComponent(svc)}/metrics`, true);
+    renderMetrics(svc, data||{});
+}
+
+function renderMetrics(svc, m) {
+    const grid=$('metrics-grid'); if (!grid) return;
+    const cards = [
+        {
+            label:'CPU Utilization', icon:'cpu', color:'blue',
+            value: num(m.cpuUsage)>0 ? `${num(m.cpuUsage).toFixed(2)} Cores` : '—',
+            pct: clamp(num(m.cpuUsage)*20,0,100),
+            hist: m.cpuHistory||generateFakeBars(8,num(m.cpuUsage)*20),
+        },
+        {
+            label:'Memory Allocation', icon:'hard-drive', color:'purple',
+            value: num(m.memoryUsage)>0 ? formatBytes(num(m.memoryUsage)) : '—',
+            pct: clamp(num(m.memoryUsage)/(4*1024*1024*1024)*100,0,100),
+            hist: m.memHistory||generateFakeBars(8, clamp(num(m.memoryUsage)/(4*1024*1024*1024)*100,0,100)),
+        },
+        {
+            label:'Request Rate', icon:'zap', color:'emerald',
+            value: m.requestRate!=null?`${num(m.requestRate).toFixed(1)}/s`:'—',
+            pct: clamp(num(m.requestRate)/10*100,0,100),
+            hist: m.rpsHistory||generateFakeBars(8, clamp(num(m.requestRate)/10*100,0,100)),
+        },
+        {
+            label:'Error Rate', icon:'x-circle', color:'red',
+            value: m.errorRate!=null?`${(num(m.errorRate)*100).toFixed(2)}%`:'—',
+            pct: clamp(num(m.errorRate)*100*5,0,100),
+            hist: m.errHistory||generateFakeBars(8, clamp(num(m.errorRate)*100*5,0,100)),
+            alert: num(m.errorRate)>0.01,
+        },
+        {
+            label:'P99 Latency', icon:'timer', color:'amber',
+            value: m.p99Latency!=null?fmtDur(num(m.p99Latency)):'—',
+            pct: clamp(num(m.p99Latency)/1000*100,0,100),
+            hist: m.latHistory||generateFakeBars(8, clamp(num(m.p99Latency)/1000*100,0,100)),
+        },
+        {
+            label:'Active Connections', icon:'link', color:'indigo',
+            value: m.activeConnections!=null?String(num(m.activeConnections)):'—',
+            pct: clamp(num(m.activeConnections)/1000*100,0,100),
+            hist: m.connHistory||generateFakeBars(8, clamp(num(m.activeConnections)/1000*100,0,100)),
+        },
+    ];
+
+    const COLOR = {blue:'bg-blue-500',purple:'bg-purple-500',emerald:'bg-emerald-500',red:'bg-red-500',amber:'bg-amber-500',indigo:'bg-indigo-500'};
+    const TCOL  = {blue:'text-blue-400',purple:'text-purple-400',emerald:'text-emerald-400',red:'text-red-400',amber:'text-amber-400',indigo:'text-indigo-400'};
+
+    grid.innerHTML = cards.map(c=>{
+        const barColor = c.alert ? 'bg-red-500' : COLOR[c.color]||'bg-slate-500';
+        const textColor = c.alert ? 'text-red-400' : TCOL[c.color]||'text-slate-400';
+        const bars = c.hist.map(v=>`<div class="metric-bar ${barColor}" style="height:${clamp(v,4,100)}%"></div>`).join('');
+        return `<div class="bg-[#0a1628] border ${c.alert?'border-red-500/30':'border-slate-800/60'} rounded-xl p-5 hover:border-slate-700 transition-colors">
+            <div class="flex items-center justify-between mb-4">
+                <div class="flex items-center gap-2">
+                    <i data-lucide="${c.icon}" class="w-4 h-4 ${textColor}"></i>
+                    <span class="text-xs font-semibold text-slate-300">${c.label}</span>
+                </div>
+                ${c.alert?'<span class="text-[9px] bg-red-500/15 text-red-400 border border-red-500/30 px-1.5 py-0.5 rounded font-bold">ALERT</span>':''}
+            </div>
+            <div class="text-2xl font-bold ${textColor} font-mono mb-4">${c.value}</div>
+            <div class="metric-bar-wrap">${bars}</div>
+        </div>`;
+    }).join('');
+    lucide.createIcons();
+}
+
+function generateFakeBars(n, base) {
+    return Array.from({length:n},(_,i)=>clamp(base*(0.6+Math.random()*0.8),2,100));
+}
+
+function formatBytes(b) {
+    if (b>=1e9) return `${(b/1e9).toFixed(1)} GB`;
+    if (b>=1e6) return `${(b/1e6).toFixed(1)} MB`;
+    if (b>=1e3) return `${(b/1e3).toFixed(1)} KB`;
+    return `${Math.round(b)} B`;
+}
+
+// ── Logs ───────────────────────────────────────────────────────────────────
+async function loadLogs() {
+    const svc=$('logs-svc')?.value||S.selectedSvc;
+    const sev=$('logs-sev')?.value||'';
+    if (!svc) return;
+
+    const url=`/api/services/${encodeURIComponent(svc)}/logs?limit=200${sev?'&severity='+encodeURIComponent(sev):''}`;
+    $('logs-cmd').textContent=`tail -f /var/log/containers/${svc}*.log${sev?' | grep '+sev:''}`;
+    const data=await apiFetch(url, true);
+    const stream=$('logs-stream'); if (!stream) return;
+
+    if (!Array.isArray(data)||data.length===0) {
+        stream.innerHTML=`<div class="text-xs text-slate-600 py-4">No logs available. Configure a log backend (SigNoz/Loki) in telemetry settings.</div>`;
+        return;
+    }
+    stream.innerHTML=data.map(renderLogLine).join('');
+    if (S.logAutoScroll) stream.scrollTop=stream.scrollHeight;
+}
+
+function renderLogLine(e) {
+    const lvl=(e.severity||e.level||'INFO').toUpperCase();
+    const cls=LOG_COLOR[lvl]||'text-slate-400';
+    const ts=e.timestamp?fmtTime(e.timestamp):'--:--:--';
+    const svc=e.serviceName||e.service||'';
+    const msg=e.body||e.message||'';
+    return `<div class="log-line ${lvl}">
+        <span class="text-slate-700">${esc(ts)}</span>
+        <span class="mx-1.5 font-bold ${cls}">[${esc(lvl)}]</span>
+        ${svc?`<span class="text-slate-600">[${esc(svc)}]</span> `:''}
+        <span class="text-slate-300">${esc(msg)}</span>
+    </div>`;
+}
+
+function toggleLogScroll() {
+    S.logAutoScroll=!S.logAutoScroll;
+    const btn=$('log-scroll-btn');
+    btn.classList.toggle('bg-indigo-500/15',S.logAutoScroll);
+    btn.classList.toggle('text-indigo-400',S.logAutoScroll);
+    btn.classList.toggle('bg-slate-800',!S.logAutoScroll);
+    btn.classList.toggle('text-slate-500',!S.logAutoScroll);
+}
+
+// ── Traces ─────────────────────────────────────────────────────────────────
+async function loadTraces() {
+    const svc=$('traces-svc')?.value||S.selectedSvc;
+    if (!svc) return;
+    const data=await apiFetch(`/api/services/${encodeURIComponent(svc)}/traces?limit=50`, true);
+    renderTraces(data);
+}
+
+function renderTraces(data) {
+    const body=$('traces-body'); if (!body) return;
+    if (!Array.isArray(data)||data.length===0) {
+        body.innerHTML=`<tr><td colspan="6" class="px-4 py-8 text-xs text-slate-600">No traces available. Configure Jaeger or SigNoz as telemetry backend.</td></tr>`;
+        return;
+    }
+    body.innerHTML=data.map(t=>{
+        const err=t.hasError||t.error;
+        const sc=err?'bg-red-500/10 text-red-400 border border-red-500/20':'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20';
+        return `<tr class="trace-row">
+            <td class="px-4 py-2.5 font-mono text-[10px] text-indigo-400">${esc((t.traceId||t.id||'').slice(0,16))}…</td>
+            <td class="px-4 py-2.5 text-slate-300 text-xs">${esc(t.rootSpan||t.operationName||t.name||'—')}</td>
+            <td class="px-4 py-2.5 font-mono text-[11px] text-slate-400">${esc(fmtDur(t.duration||t.durationMs))}</td>
+            <td class="px-4 py-2.5 text-[11px] text-slate-500">${esc(t.spanCount||t.spans||'—')}</td>
+            <td class="px-4 py-2.5"><span class="px-1.5 py-0.5 rounded text-[9px] font-bold ${sc}">${err?'ERROR':'OK'}</span></td>
+            <td class="px-4 py-2.5 text-right font-mono text-[10px] text-slate-600">${esc(fmtTime(t.startTime||t.timestamp))}</td>
+        </tr>`;
+    }).join('');
+}
+
+// ── RCA Rules ──────────────────────────────────────────────────────────────
+function renderRules() {
+    const body=$('rules-body'); if (!body) return;
+    $('rules-count').textContent=`${S.rules.length} Rules`;
+    if (!S.rules.length) {
+        body.innerHTML=`<tr><td colspan="8" class="px-4 py-8 text-xs text-slate-600">No RCACorrelationRule resources found.</td></tr>`;
+        return;
+    }
+    body.innerHTML=S.rules.map(r=>{
+        const sc=SEV_BADGE[r.firesSeverity]||SEV_BADGE.P4;
+        const conds=(Array.isArray(r.conditions)?r.conditions:[]).join(' + ');
+        const autoTag=r.autoGenerated?'<span class="text-[9px] bg-slate-700 text-slate-400 px-1.5 py-0.5 rounded font-mono ml-1">auto</span>':'';
+        return `<tr class="hover:bg-slate-800/20 transition-colors">
+            <td class="px-4 py-3 font-mono text-[11px] font-bold text-slate-400">${esc(r.priority||'—')}</td>
+            <td class="px-4 py-3 font-medium text-slate-200 text-xs">${esc(r.name)}${autoTag}</td>
+            <td class="px-4 py-3 font-mono text-[10px] text-indigo-300">${esc(r.triggerEvent||'—')}</td>
+            <td class="px-4 py-3 font-mono text-[10px] text-slate-300">${esc(r.firesType||'—')}</td>
+            <td class="px-4 py-3"><span class="px-1.5 py-0.5 rounded text-[10px] font-bold font-mono border ${sc}">${esc(r.firesSeverity||'—')}</span></td>
+            <td class="px-4 py-3 text-[10px] text-slate-500 font-mono max-w-xs truncate">${esc(conds||'none')}</td>
+            <td class="px-4 py-3 text-[10px] text-slate-500">${esc(r.agentSelector||'all')}</td>
+            <td class="px-4 py-3 text-right font-mono text-[10px] text-slate-600">${esc(r.age||'—')}</td>
+        </tr>`;
+    }).join('');
+}
+
+// ── RCA Agents ────────────────────────────────────────────────────────────
+async function refreshAgents() {
+    const data=await apiFetch('/api/agents', true);
+    if (Array.isArray(data)) S.agents=data;
+    renderAgents();
+}
+
+function renderAgents() {
+    const grid=$('agents-grid'); if (!grid) return;
+    const agents=S.agents.length?S.agents:(S.stats.agents||[]).map(a=>({...a,conditions:[],watchNamespaces:a.watchNamespaces||[]}));
+    if (!agents.length) {
+        grid.innerHTML=`<div class="text-xs text-slate-600 text-center py-12">No RCAAgent resources found.</div>`;
+        return;
+    }
+    grid.innerHTML=agents.map(a=>{
+        const ok=a.healthy!==false;
+        const stCls=ok?'bg-emerald-500/10 text-emerald-400 border-emerald-500/30':'bg-red-500/10 text-red-400 border-red-500/30';
+        const dotCls=ok?'bg-emerald-500':'bg-red-500 pulse-dot';
+        const nss=(a.watchNamespaces||[]);
+        const nsHtml=nss.length?nss.map(n=>`<span class="px-2 py-0.5 rounded-full bg-slate-700/60 text-slate-400 text-[10px] font-mono border border-slate-700">${esc(n)}</span>`).join('')
+            :'<span class="text-[10px] text-slate-600 font-mono">all namespaces</span>';
+        const caps=[];
+        if (a.hasSlack) caps.push('<span class="text-[9px] px-1.5 py-0.5 rounded bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 font-mono">Slack</span>');
+        if (a.hasPagerDuty) caps.push('<span class="text-[9px] px-1.5 py-0.5 rounded bg-orange-500/10 text-orange-400 border border-orange-500/20 font-mono">PagerDuty</span>');
+        const conds=(a.conditions||[]).map(c=>`
+            <div class="flex items-center justify-between text-[10px] py-1 border-b border-slate-800/30 last:border-0">
+                <span class="text-slate-500 font-mono">${esc(c.type)}</span>
+                <span class="font-bold ${c.status==='True'?'text-emerald-400':'text-red-400'}">${esc(c.status)}</span>
+            </div>`).join('');
+        return `<div class="bg-[#0a1628] border ${ok?'border-slate-800/60':'border-red-500/20'} rounded-xl p-5 hover:border-slate-700 transition-colors">
+            <div class="flex items-center justify-between mb-4">
+                <div class="flex items-center gap-3">
+                    <div class="w-9 h-9 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center">
+                        <i data-lucide="cpu" class="w-4 h-4 text-indigo-400"></i>
+                    </div>
+                    <div>
+                        <div class="text-sm font-bold text-white flex items-center gap-2">
+                            <span class="w-2 h-2 rounded-full ${dotCls}"></span>
+                            ${esc(a.name)}
+                        </div>
+                        ${a.namespace?`<div class="text-[10px] text-slate-600 font-mono mt-0.5">${esc(a.namespace)}</div>`:''}
+                    </div>
+                </div>
+                <span class="px-2 py-0.5 rounded text-[10px] font-bold border ${stCls}">${ok?'HEALTHY':'DEGRADED'}</span>
+            </div>
+            <div class="space-y-3">
+                <div>
+                    <div class="text-[10px] text-slate-600 uppercase tracking-wider mb-1.5">Watch Namespaces</div>
+                    <div class="flex flex-wrap gap-1">${nsHtml}</div>
+                </div>
+                ${caps.length?`<div><div class="text-[10px] text-slate-600 uppercase tracking-wider mb-1.5">Notifications</div><div class="flex gap-1.5">${caps.join('')}</div></div>`:''}
+                ${a.retentionDuration?`<div class="flex justify-between text-[10px]"><span class="text-slate-600">Retention</span><span class="font-mono text-slate-400">${esc(a.retentionDuration)}</span></div>`:''}
+                ${a.signalMappings>0?`<div class="flex justify-between text-[10px]"><span class="text-slate-600">Signal Mappings</span><span class="font-mono text-slate-400">${a.signalMappings} custom</span></div>`:''}
+                ${a.createdAt?`<div class="flex justify-between text-[10px]"><span class="text-slate-600">Created</span><span class="font-mono text-slate-400">${esc(relTime(a.createdAt))}</span></div>`:''}
+                ${conds?`<div class="mt-2 bg-slate-900/40 rounded-lg p-2">${conds}</div>`:''}
+            </div>
+        </div>`;
+    }).join('');
+    lucide.createIcons();
+}
+
+// ── Correlation Stream ──────────────────────────────────────────────────────
+function initSSE() {
+    if (S.sseConn) { try{S.sseConn.close();}catch(e){} }
+    const es=new EventSource('/api/stream/correlation');
+    S.sseConn=es;
+    es.addEventListener('connected', ()=>{
+        $('sse-status').innerHTML='<span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span><span>Live</span>';
+    });
+    es.addEventListener('signal.new', e=>{
+        try { const d=JSON.parse(e.data); pushStreamEvent(d); } catch(_){}
+    });
+    es.addEventListener('incident.created', e=>{
+        try { const d=JSON.parse(e.data); pushStreamEvent({...d, source:'rca-operator'}); refreshAll(); } catch(_){}
+    });
+    es.onerror=()=>{
+        $('sse-status').innerHTML='<span class="w-1.5 h-1.5 rounded-full bg-slate-600"></span><span class="text-slate-600">Polling</span>';
+    };
+}
+
+function pushStreamEvent(ev) {
+    S.sseStreamEvents.unshift(ev);
+    if (S.sseStreamEvents.length>30) S.sseStreamEvents.pop();
+    renderStreamCards();
+}
+
+function buildStreamEvents() {
+    // Merge SSE events with incident-derived events
+    const incEvents = S.incidents.slice(-12).flatMap(inc=>{
+        const src='rca-operator';
+        const ev=[{
+            time: incStart(inc),
+            source: src,
+            title: `${inc.incidentType||'Incident'} • ${inc.severity||''}`,
+            msg: (inc.summary||serviceFor(inc)).slice(0,80),
+            color:'rca-operator',
+        }];
+        if (inc.rca?.rootCause) ev.push({
+            time: inc.rca.investigatedAt||incStart(inc),
+            source:'ai', title:'Root Cause Identified',
+            msg: inc.rca.rootCause.slice(0,80), color:'ai',
         });
-      }
-      h+='</div></div>';
-    } else if(inc.phase==='Active'){
-      h+='<div><div class="section-title">\u{1F916} AI Root Cause Analysis</div>';
-      h+='<div class="card" style="cursor:pointer" onclick="window._investigate(\''+esc(inc.namespace)+'\',\''+esc(inc.name)+'\')">';
-      h+='<span class="cmd-num">\u{1F916}</span><code class="cmd-code">Trigger AI Investigation</code></div></div>';
-    }
-
-    /* Related Traces */
-    if(inc.relatedTraces&&inc.relatedTraces.length){
-      h+='<div><div class="section-title">Related Traces ('+inc.relatedTraces.length+')</div>';
-      inc.relatedTraces.forEach(function(t){
-        h+='<div class="card"><code class="cmd-code" style="font-size:11px">'+esc(t)+'</code>';
-        h+='<button class="copy-btn" onclick="window._copy(this,\''+esc(t)+'\')">copy</button></div>';
-      });
-      h+='</div>';
-    }
-
-    /* Blast Radius */
-    if(inc.blastRadius&&inc.blastRadius.length){
-      h+='<div><div class="section-title">Blast Radius ('+inc.blastRadius.length+' services)</div>';
-      h+='<div style="display:flex;flex-wrap:wrap;gap:4px">';
-      inc.blastRadius.forEach(function(s){h+='<span class="topo-blast-tag">'+esc(s)+'</span>'});
-      h+='</div></div>';
-    }
-
-    /* Conditions */
-    h+='<div><div class="section-title">Status Conditions</div>';
-    [{type:'Available',status:inc.phase==='Active'?'True':inc.phase==='Resolved'?'False':'Unknown',
-      reason:inc.phase==='Active'?'IncidentActive':'IncidentResolved',
-      msg:sev+' '+inc.incidentType+' incident \u2014 '+inc.phase},
-     {type:'Progressing',status:inc.phase==='Detecting'?'True':'False',
-      reason:inc.phase==='Detecting'?'CorrelatingSignals':'IncidentStable',
-      msg:inc.phase==='Detecting'?'Correlator is accumulating signals':'Incident not actively changing'},
-     {type:'Degraded',status:'False',reason:'OperatorHealthy',msg:'All notifications dispatched successfully'}
-    ].forEach(function(c){
-      var cls=c.status==='True'?'cond-true':c.status==='Unknown'?'cond-unknown':'cond-false';
-      h+='<div class="card" style="flex-wrap:wrap"><div style="display:flex;align-items:center;gap:8px;flex:1;min-width:0">';
-      h+='<span class="cond-type">'+esc(c.type)+'</span>';
-      h+='<span class="cond-badge '+cls+'">'+c.status+'</span>';
-      h+='<span class="cond-reason">'+esc(c.reason)+'</span></div>';
-      h+='<div class="cond-msg" style="width:100%">'+esc(c.msg)+'</div></div>';
+        return ev;
     });
-    h+='</div>';
+    const all=[...S.sseStreamEvents.map(e=>({...e, fromSSE:true})), ...incEvents]
+        .sort((a,b)=>new Date(a.time)-new Date(b.time));
+    return all.slice(-18);
+}
 
-    h+='</div>';
-    p.innerHTML=h;
-  }
+function renderStreamCards() {
+    const container=$('stream-cards'); if (!container) return;
+    const events=buildStreamEvents();
+    if (!events.length) {
+        container.innerHTML=`<div class="flex items-center text-xs text-slate-700 px-2">No correlation events yet.</div>`;
+        return;
+    }
+    container.innerHTML=events.map(ev=>{
+        const src=(ev.source||'').toLowerCase().replace(/[^a-z-]/g,'-');
+        const cls=STREAM_SOURCE_COLOR[src]||STREAM_SOURCE_COLOR['rca-operator'];
+        const srcLabel=(ev.source||'RCA-OPERATOR').toUpperCase();
+        const dot=cls.includes('red')?'bg-red-500':cls.includes('blue')?'bg-blue-500':cls.includes('violet')?'bg-violet-500':cls.includes('emerald')?'bg-emerald-500':'bg-slate-500';
+        return `<div class="relative flex flex-col items-center group w-52 shrink-0 mt-1">
+            <div class="w-3 h-3 rounded-full ${dot} border-2 border-[#0a1628] z-10 mb-2"></div>
+            <div class="bg-[#060d1a] border ${cls} rounded-xl p-3 w-full group-hover:-translate-y-0.5 transition-transform">
+                <div class="flex justify-between items-center mb-1">
+                    <span class="text-[9px] uppercase tracking-wider font-bold opacity-80">${esc(srcLabel)}</span>
+                    <span class="font-mono text-[9px] text-slate-600">${esc(fmtTime(ev.time))}</span>
+                </div>
+                <h4 class="text-xs font-bold text-white mb-0.5 leading-tight">${esc(ev.title||'')}</h4>
+                <p class="text-[10px] opacity-70 leading-snug line-clamp-2">${esc(ev.msg||'')}</p>
+            </div>
+        </div>`;
+    }).join('');
+    // Scroll to end
+    const wrap=$('stream-wrap');
+    if (wrap) wrap.scrollLeft=wrap.scrollWidth;
+}
 
-  /* ── Tab content renderers ─────────────────── */
-  function renderRulesTab(){
-    var el=document.getElementById('list-pane');
-    document.getElementById('detail-panel').style.display='none';
-    el.className='list-pane full';
-    var h='<div class="list-header"><span style="min-width:40px">Pri</span><span style="flex:1">Name</span>'+
-      '<span style="min-width:120px">Trigger</span><span style="min-width:100px">Fires</span>'+
-      '<span style="min-width:50px">Sev</span><span style="min-width:100px">Conditions</span>'+
-      '<span style="min-width:60px">Selector</span><span style="min-width:60px">Age</span></div>';
-    if(!rules.length){
-      h+='<div class="empty-state"><div class="empty-state-title">No RCACorrelationRule CRDs found</div>'+
-        '<div class="empty-state-sub">Deploy rules from config/rules/ or create custom rules</div></div>';
+// ── Header ────────────────────────────────────────────────────────────────
+function updateHeader() {
+    const active=S.incidents.filter(i=>i.phase==='Active'||i.phase==='Detecting').length;
+    const pill=$('active-pill');
+    const txt=$('pill-text'), dot=$('pill-dot');
+    if (active>0) {
+        txt.textContent=`${active} ACTIVE INCIDENT${active>1?'S':''}`;
+        pill.className='flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-bold tracking-wide border transition-colors cursor-pointer bg-red-500/10 border-red-500/30 text-red-400';
+        dot.className='w-1.5 h-1.5 rounded-full pulse-dot bg-red-500';
     } else {
-      rules.forEach(function(r){
-        var condText=(r.conditions||[]).join(', ')||'none';
-        h+='<div class="data-row">';
-        h+='<span style="font-family:var(--font-mono);font-size:13px;font-weight:600;color:var(--accent);min-width:40px;text-align:right">'+r.priority+'</span>';
-        h+='<div style="flex:1;min-width:0;font-size:13px;font-weight:500">'+esc(r.name)+'</div>';
-        h+='<span style="font-family:var(--font-mono);font-size:12px;min-width:120px">'+esc(r.triggerEvent)+'</span>';
-        h+='<span style="font-size:12px;min-width:100px">'+esc(r.firesType)+'</span>';
-        h+='<span class="sev sm sev-'+r.firesSeverity+'" style="min-width:50px">'+r.firesSeverity+'</span>';
-        h+='<span style="font-size:11px;color:var(--text-tertiary);min-width:100px" title="'+esc(condText)+'">'+esc(condText.length>35?condText.slice(0,35)+'\u2026':condText)+'</span>';
-        h+='<span style="font-size:11px;color:var(--text-tertiary);min-width:60px">'+esc(r.agentSelector)+'</span>';
-        h+='<span style="font-family:var(--font-mono);font-size:11px;color:var(--text-tertiary);min-width:60px">'+esc(r.age)+'</span>';
-        h+='</div>';
-      });
+        txt.textContent='ALL CLEAR';
+        pill.className='flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-bold tracking-wide border transition-colors cursor-pointer bg-emerald-500/10 border-emerald-500/30 text-emerald-400';
+        dot.className='w-1.5 h-1.5 rounded-full bg-emerald-500';
     }
-    el.innerHTML=h;
-  }
 
-  function renderAgentsTab(){
-    var el=document.getElementById('list-pane');
-    document.getElementById('detail-panel').style.display='none';
-    el.className='list-pane full';
-    var agents=stats.agents||[];
-    if(!agents.length){
-      el.innerHTML='<div class="empty-state"><div class="empty-state-title">No RCAAgent resources found</div></div>';return;
-    }
-    var h='<div class="list-header"><span style="width:20px"></span><span style="flex:1">Name</span>'+
-      '<span style="min-width:200px">Watch Namespaces</span><span style="min-width:80px">Status</span></div>';
-    agents.forEach(function(a){
-      var name=typeof a==='string'?a:a.name;var healthy=typeof a==='string'?true:a.healthy!==false;
-      var ns=(typeof a!=='string'&&a.watchNamespaces)?a.watchNamespaces:[];
-      h+='<div class="data-row"><span style="width:20px"><span style="width:8px;height:8px;border-radius:50%;background:'+(healthy?'var(--green)':'var(--red)')+';display:inline-block"></span></span>';
-      h+='<div style="flex:1;font-size:13px;font-weight:500">'+esc(name)+'</div>';
-      h+='<span style="font-size:12px;color:var(--text-secondary);min-width:200px">'+ns.map(esc).join(', ')+'</span>';
-      h+='<span style="font-family:var(--font-mono);font-size:11px;font-weight:600;min-width:80px;color:'+(healthy?'var(--green)':'var(--red)')+'">'+(healthy?'HEALTHY':'DEGRADED')+'</span>';
-      h+='</div>';
-    });
-    el.innerHTML=h;
-  }
+    const svcs=S.nodesData.length||getServices().length;
+    $('hdr-svc').textContent=`${svcs} Services`;
+    $('hdr-agt').textContent=`${(S.stats.agents||[]).length} Agents`;
+    const failing=S.nodesData.filter(n=>n.status==='critical').length||active;
+    $('hdr-fail').textContent=`${failing} Failing`;
 
-  function renderNsTab(){
-    var el=document.getElementById('list-pane');
-    document.getElementById('detail-panel').style.display='none';
-    el.className='list-pane full';
-    var ns=stats.namespaces||{};var keys=Object.keys(ns).sort();
-    if(!keys.length){
-      el.innerHTML='<div class="empty-state"><div class="empty-state-title">No namespaces found</div></div>';return;
-    }
-    var h='<div class="list-header"><span style="width:20px"></span><span style="flex:1">Namespace</span>'+
-      '<span style="min-width:100px">Active</span><span style="min-width:100px">Monitored</span>'+
-      '<span style="min-width:200px">Incident Types</span></div>';
-    keys.forEach(function(k){
-      var e=ns[k];var typesInNs={};incidents.forEach(function(i){if(i.namespace===k&&i.phase!=='Resolved')typesInNs[i.incidentType]=true});
-      var typeList=Object.keys(typesInNs).sort().join(', ')||'\u2014';
-      h+='<div class="data-row"><span style="width:20px"><span style="width:8px;height:8px;border-radius:50%;background:'+(e.monitored?'var(--green)':'var(--text-tertiary)')+';opacity:'+(e.monitored?'1':'0.3')+';display:inline-block"></span></span>';
-      h+='<div style="flex:1;font-size:13px;font-weight:500">'+esc(k)+'</div>';
-      h+='<span style="font-family:var(--font-mono);font-size:14px;font-weight:600;min-width:100px;color:'+(e.active>0?'var(--red)':'var(--text-tertiary)')+'">'+e.active+'</span>';
-      h+='<span style="font-size:11px;font-weight:600;min-width:100px;color:'+(e.monitored?'var(--green)':'var(--text-tertiary)')+'">'+(e.monitored?'YES':'NO')+'</span>';
-      h+='<span style="font-size:11px;color:var(--text-secondary);min-width:200px">'+esc(typeList)+'</span>';
-      h+='</div>';
-    });
-    el.innerHTML=h;
-  }
+    // Namespace from first incident or first agent namespace
+    const ns=S.incidents[0]?.namespace||S.agents[0]?.namespace||'—';
+    $('hdr-ns').textContent=ns;
+}
 
-  function renderStatusBar(){
-    var el=document.getElementById('status-bar');
-    var f=getFiltered();
-    el.innerHTML=pulseDot(connected?'var(--green)':'var(--red)',5)+
-      '<span>'+(connected?'Connected':'Disconnected')+'</span>'+
-      '<span class="status-sep"></span><span>Polling 10s</span>'+
-      '<span class="status-sep"></span><span>'+f.length+'/'+incidents.length+' shown</span>'+
-      '<div style="flex:1"></div><span>RCA Operator v0.0.16</span>';
-  }
+// ── Render all ────────────────────────────────────────────────────────────
+function renderAll() {
+    updateHeader();
+    renderTopology();
+    renderIncidentsList();
+    if (S.selectedIncKey) renderIncidentDetail();
+    renderRules();
+    renderStreamCards();
+    if (S.tab==='metrics') loadMetrics();
+    if (S.tab==='logs')    loadLogs();
+    if (S.tab==='traces')  loadTraces();
+    if (S.tab==='agents')  renderAgents();
+    lucide.createIcons();
+}
 
-  /* ── Event Handlers ────────────────────────── */
-  window._sel=function(key){
-    selectedKey=selectedKey===key?null:key;
-    renderIncidents();renderDetail();
-    if(selectedKey){
-      var inc=incidents.find(function(i){return incKey(i)===selectedKey});
-      if(inc){
-        fetch('/api/incidents/'+encodeURIComponent(inc.namespace)+'/'+encodeURIComponent(inc.name))
-          .then(function(r){return r.json()})
-          .then(function(d){
-            if(d.traceId)inc.traceId=d.traceId;
-            if(d.firedRule)inc.firedRule=d.firedRule;
-            if(selectedKey===key)renderDetail();
-          }).catch(function(){});
-      }
-    }
-  };
-  window._close=function(){selectedKey=null;renderIncidents();renderDetail()};
-  window._investigate=function(ns,name){
-    if(!confirm('Trigger AI investigation for '+ns+'/'+name+'?'))return;
-    fetch('/api/investigate/'+encodeURIComponent(ns)+'/'+encodeURIComponent(name),{method:'POST'})
-      .then(function(r){
-        if(!r.ok)return r.text().then(function(t){throw new Error(t)});
-        return r.json();
-      }).then(function(data){
-        alert('AI Investigation started.\nStatus: '+(data.status||'unknown'));
-      }).catch(function(e){alert('Investigation failed: '+e.message)});
-  };
-  window._f=function(type,val){
-    if(filters[type]===val&&val!=='all')filters[type]='all';else filters[type]=val;
-    render();
-  };
-  window._copy=function(btn,text){copyToClip(text,btn)};
-  window._tab=function(tab){
-    activeTab=tab;selectedKey=null;
-    document.querySelectorAll('#nav .nav-item').forEach(function(el){
-      if(el.getAttribute('data-tab')===tab){
-        el.className='nav-item active';
-      } else {
-        el.className='nav-item';
-      }
-    });
-    render();
-  };
-  window._toggleSignals=function(){
-    signalsOpen=!signalsOpen;
-    var body=document.getElementById('signals-body');
-    var icon=document.querySelector('.toggle-icon');
-    if(body)body.style.display=signalsOpen?'':'none';
-    if(icon){if(signalsOpen)icon.classList.remove('collapsed');else icon.classList.add('collapsed')}
-  };
-  window._toggleTheme=function(){applyTheme(theme==='dark'?'light':'dark');render()};
-  window._setTZ=function(tz){
-    if(tzOptions.indexOf(tz)===-1)return;
-    selTZ=tz;try{localStorage.setItem(tzKey,tz)}catch(e){}
-    renderIncidents();renderDetail();tickClock();
-  };
+// ── Export ────────────────────────────────────────────────────────────────
+function exportReport() {
+    const rows=[['Name','Namespace','Type','Severity','Phase','First Seen','Elapsed']];
+    S.incidents.forEach(i=>rows.push([i.name,i.namespace,i.incidentType||'',i.severity||'',i.phase||'',incStart(i),elapsed(incStart(i),i.resolvedAt)]));
+    const csv=rows.map(r=>r.map(v=>`"${String(v).replace(/"/g,'""')}"`).join(',')).join('\n');
+    const a=document.createElement('a');
+    a.href='data:text/csv;charset=utf-8,'+encodeURIComponent(csv);
+    a.download=`rca-incidents-${new Date().toISOString().slice(0,10)}.csv`;
+    a.click();
+    showToast('Report exported');
+}
 
-  /* Keyboard */
-  document.addEventListener('keydown',function(e){
-    if(e.target.tagName==='INPUT'||e.target.tagName==='SELECT')return;
-    if(e.key==='Escape'){selectedKey=null;render();return}
-    if(e.key==='j'||e.key==='k'){
-      e.preventDefault();
-      var list=getSorted(getFiltered());
-      var idx=list.findIndex(function(i){return incKey(i)===selectedKey});
-      var next=e.key==='j'?Math.min(idx+1,list.length-1):Math.max(idx-1,0);
-      if(list[next]){selectedKey=incKey(list[next]);renderIncidents();renderDetail()}
-    }
-  });
+// ── Boot ──────────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', ()=>{
+    lucide.createIcons();
+    switchTab('topology');
+    startPolling();
+    initSSE();
+    // Re-render correlation every 5s if SSE not active
+    setInterval(renderStreamCards, 5000);
+});
 
-  /* Live duration tick */
-  setInterval(function(){
-    var el=document.getElementById('live-dur');
-    if(!el||!selectedKey)return;
-    var inc=incidents.find(function(i){return incKey(i)===selectedKey});
-    if(!inc||inc.phase==='Resolved')return;
-    el.innerHTML='<span style="color:'+(inc.phase==='Active'?'var(--amber)':'var(--purple)')+'">'+liveDur(startTime(inc))+'</span>';
-  },1000);
+// expose for inline handlers
+window.switchTab=switchTab;
+window.selectNode=selectNode;
+window.closeTopoPanel=closeTopoPanel;
+window.startDrag=startDrag;
+window.resetLayout=resetLayout;
+window.openServiceTraces=()=>{ switchTab('traces'); };
+window.selectInc=selectInc;
+window.setIncPhase=setIncPhase;
+window.filterIncidents=filterIncidents;
+window.triggerRCA=triggerRCA;
+window.viewTrace=viewTrace;
+window.copyCmd=copyCmd;
+window.loadMetrics=loadMetrics;
+window.onMetricsSvcChange=onMetricsSvcChange;
+window.loadLogs=loadLogs;
+window.toggleLogScroll=toggleLogScroll;
+window.loadTraces=loadTraces;
+window.refreshAgents=refreshAgents;
+window.exportReport=exportReport;
+window.showToast=showToast;
 
-  /* Clock */
-  function tickClock(){
-    var el=document.getElementById('clock');if(!el)return;
-    var now=new Date();var tz=activeTZ();
-    el.textContent=fmtClock(now,tz)+' '+fmtZone(now,tz);
-  }
-
-  /* Init */
-  document.getElementById('conn-dot').innerHTML=pulseDot('var(--green)',8);
-  fetchAll();
-  setInterval(fetchAll,10000);
-  setInterval(tickClock,1000);
-  tickClock();
 })();
 </script>
 </body>

--- a/internal/telemetry/jaeger_client.go
+++ b/internal/telemetry/jaeger_client.go
@@ -283,7 +283,7 @@ func (td *jaegerTraceData) toTraceSummary() TraceSummary {
 			}
 			summary.RootSpan = s.OperationName
 			summary.StartTime = time.UnixMicro(s.StartTime)
-			summary.Duration = time.Duration(s.Duration) * time.Microsecond
+			summary.Duration = float64(s.Duration) / 1000.0 // μs → ms
 		}
 
 		// Check for errors
@@ -306,8 +306,8 @@ func (td *jaegerTraceData) toTrace() *Trace {
 			TraceID:       s.TraceID,
 			SpanID:        s.SpanID,
 			OperationName: s.OperationName,
-			StartTime:     time.UnixMicro(s.StartTime),
-			Duration:      time.Duration(s.Duration) * time.Microsecond,
+			StartTime: time.UnixMicro(s.StartTime),
+			Duration:  float64(s.Duration) / 1000.0, // μs → ms
 			Tags:          kvToMap(s.Tags),
 		}
 

--- a/internal/telemetry/jaeger_client.go
+++ b/internal/telemetry/jaeger_client.go
@@ -306,8 +306,8 @@ func (td *jaegerTraceData) toTrace() *Trace {
 			TraceID:       s.TraceID,
 			SpanID:        s.SpanID,
 			OperationName: s.OperationName,
-			StartTime: time.UnixMicro(s.StartTime),
-			Duration:  float64(s.Duration) / 1000.0, // μs → ms
+			StartTime:     time.UnixMicro(s.StartTime),
+			Duration:      float64(s.Duration) / 1000.0, // μs → ms
 			Tags:          kvToMap(s.Tags),
 		}
 

--- a/internal/telemetry/prometheus_client.go
+++ b/internal/telemetry/prometheus_client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -92,39 +93,56 @@ func (c *PrometheusClient) GetServiceMetrics(ctx context.Context, service string
 
 	metrics := &ServiceMetrics{ServiceName: service}
 
+	// safeVal returns v only if it is a finite, non-NaN number, otherwise 0.
+	safeVal := func(v float64) float64 {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return 0
+		}
+		return v
+	}
+
 	// Request rate
 	rateQuery := fmt.Sprintf(`sum(rate(http_server_request_duration_seconds_count{service_name="%s"}[5m]))`, service)
 	rateSeries, err := c.QueryMetric(ctx, rateQuery, start, end, step)
 	if err == nil && len(rateSeries) > 0 && len(rateSeries[0].Datapoints) > 0 {
-		metrics.RequestRate = lastValue(rateSeries[0].Datapoints)
+		metrics.RequestRate = safeVal(lastValue(rateSeries[0].Datapoints))
 	}
 
 	// Error rate
 	errQuery := fmt.Sprintf(`sum(rate(http_server_request_duration_seconds_count{service_name="%s",http_response_status_code=~"5.."}[5m]))`, service)
 	errSeries, err := c.QueryMetric(ctx, errQuery, start, end, step)
 	if err == nil && len(errSeries) > 0 && len(errSeries[0].Datapoints) > 0 {
-		metrics.ErrorRate = lastValue(errSeries[0].Datapoints)
+		metrics.ErrorRate = safeVal(lastValue(errSeries[0].Datapoints))
 	}
 
-	// P99 latency
+	// P99 latency — histogram_quantile returns NaN when no observations exist
 	latQuery := fmt.Sprintf(`histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{service_name="%s"}[5m])) by (le))`, service)
 	latSeries, err := c.QueryMetric(ctx, latQuery, start, end, step)
 	if err == nil && len(latSeries) > 0 && len(latSeries[0].Datapoints) > 0 {
-		metrics.P99Latency = lastValue(latSeries[0].Datapoints) * 1000 // s -> ms
+		if v := safeVal(lastValue(latSeries[0].Datapoints)); v > 0 {
+			metrics.P99Latency = v * 1000 // s → ms
+		}
 	}
 
 	// CPU usage
 	cpuQuery := fmt.Sprintf(`sum(rate(container_cpu_usage_seconds_total{pod=~"%s.*"}[5m]))`, service)
 	cpuSeries, err := c.QueryMetric(ctx, cpuQuery, start, end, step)
 	if err == nil && len(cpuSeries) > 0 && len(cpuSeries[0].Datapoints) > 0 {
-		metrics.CPUUsage = lastValue(cpuSeries[0].Datapoints)
+		metrics.CPUUsage = safeVal(lastValue(cpuSeries[0].Datapoints))
 	}
 
 	// Memory usage
 	memQuery := fmt.Sprintf(`sum(container_memory_working_set_bytes{pod=~"%s.*"})`, service)
 	memSeries, err := c.QueryMetric(ctx, memQuery, start, end, step)
 	if err == nil && len(memSeries) > 0 && len(memSeries[0].Datapoints) > 0 {
-		metrics.MemoryUsage = lastValue(memSeries[0].Datapoints)
+		metrics.MemoryUsage = safeVal(lastValue(memSeries[0].Datapoints))
+	}
+
+	// Active connections (OTel HTTP semantic conventions: http.server.active_requests)
+	connQuery := fmt.Sprintf(`sum(http_server_active_requests{service_name="%s"})`, service)
+	connSeries, err := c.QueryMetric(ctx, connQuery, start, end, step)
+	if err == nil && len(connSeries) > 0 && len(connSeries[0].Datapoints) > 0 {
+		metrics.ActiveConnections = safeVal(lastValue(connSeries[0].Datapoints))
 	}
 
 	return metrics, nil
@@ -225,7 +243,7 @@ func (d *promResultData) toMetricSeries() []MetricSeries {
 				continue
 			}
 			val, err := strconv.ParseFloat(valStr, 64)
-			if err != nil {
+			if err != nil || math.IsNaN(val) || math.IsInf(val, 0) {
 				continue
 			}
 			series.Datapoints = append(series.Datapoints, Datapoint{

--- a/internal/telemetry/signoz_client.go
+++ b/internal/telemetry/signoz_client.go
@@ -310,7 +310,7 @@ func (r *signozTracesResponse) toTraceSummaries() []TraceSummary {
 			RootService: t.RootServiceName,
 			RootSpan:    t.RootSpanName,
 			StartTime:   time.Unix(0, t.StartTimeUnix),
-			Duration:    time.Duration(t.DurationNano),
+			Duration:    float64(t.DurationNano) / 1e6, // ns → ms
 			SpanCount:   t.SpanCount,
 			HasError:    t.HasError,
 		})
@@ -348,7 +348,7 @@ func (r *signozTraceDetailResponse) toTrace(traceID string) *Trace {
 			OperationName: s.OperationName,
 			ServiceName:   s.ServiceName,
 			StartTime:     time.Unix(0, s.StartTimeUnix),
-			Duration:      time.Duration(s.DurationNano),
+			Duration:      float64(s.DurationNano) / 1e6, // ns → ms
 			StatusCode:    SpanStatusCode(s.StatusCode),
 			StatusMessage: s.StatusMessage,
 			Tags:          s.Tags,

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -20,13 +20,13 @@ import "time"
 
 // TraceSummary is a lightweight representation of a trace for listing.
 type TraceSummary struct {
-	TraceID     string        `json:"traceID"`
-	RootService string        `json:"rootService"`
-	RootSpan    string        `json:"rootSpan"`
-	StartTime   time.Time     `json:"startTime"`
-	Duration    time.Duration `json:"duration"`
-	SpanCount   int           `json:"spanCount"`
-	HasError    bool          `json:"hasError"`
+	TraceID     string    `json:"traceID"`
+	RootService string    `json:"rootService"`
+	RootSpan    string    `json:"rootSpan"`
+	StartTime   time.Time `json:"startTime"`
+	Duration    float64   `json:"duration"` // milliseconds (for frontend fmtDur compatibility)
+	SpanCount   int       `json:"spanCount"`
+	HasError    bool      `json:"hasError"`
 }
 
 // Trace is a full distributed trace containing all its spans.
@@ -43,7 +43,7 @@ type Span struct {
 	OperationName string            `json:"operationName"`
 	ServiceName   string            `json:"serviceName"`
 	StartTime     time.Time         `json:"startTime"`
-	Duration      time.Duration     `json:"duration"`
+	Duration      float64           `json:"duration"` // milliseconds
 	StatusCode    SpanStatusCode    `json:"statusCode"`
 	StatusMessage string            `json:"statusMessage,omitempty"`
 	Tags          map[string]string `json:"tags,omitempty"`
@@ -79,14 +79,15 @@ type Datapoint struct {
 
 // ServiceMetrics contains key metrics for a service over a time window.
 type ServiceMetrics struct {
-	ServiceName string  `json:"serviceName"`
-	RequestRate float64 `json:"requestRate"` // req/s
-	ErrorRate   float64 `json:"errorRate"`   // errors/s
-	P50Latency  float64 `json:"p50Latency"`  // ms
-	P95Latency  float64 `json:"p95Latency"`  // ms
-	P99Latency  float64 `json:"p99Latency"`  // ms
-	CPUUsage    float64 `json:"cpuUsage"`    // cores
-	MemoryUsage float64 `json:"memoryUsage"` // bytes
+	ServiceName       string  `json:"serviceName"`
+	RequestRate       float64 `json:"requestRate"`       // req/s
+	ErrorRate         float64 `json:"errorRate"`         // errors/s
+	P50Latency        float64 `json:"p50Latency"`        // ms
+	P95Latency        float64 `json:"p95Latency"`        // ms
+	P99Latency        float64 `json:"p99Latency"`        // ms
+	CPUUsage          float64 `json:"cpuUsage"`          // cores
+	MemoryUsage       float64 `json:"memoryUsage"`       // bytes
+	ActiveConnections float64 `json:"activeConnections"` // count
 }
 
 // LogEntry represents a single log line from the observability backend.


### PR DESCRIPTION
- Updated jaeger_client.go to convert duration from microseconds to milliseconds as float64.
- Modified prometheus_client.go to ensure safe handling of NaN and infinite values for various metrics, including request rate, error rate, P99 latency, CPU usage, memory usage, and active connections.
- Adjusted signoz_client.go to convert duration from nanoseconds to milliseconds as float64.
- Changed types.go to reflect the new float64 duration fields in TraceSummary, Span, and ServiceMetrics structs for compatibility with frontend formatting.

## What does this PR do?
<!-- One paragraph summary -->

## Why?
<!-- Context and/or link to the issue -->

## How was it tested?
<!-- Unit tests / manual validation / E2E steps -->

### Commands run
```bash
make lint
make test
make build
# optional when relevant:
# make test-e2e
```

## Scope
- [ ] This PR is focused on one concern (feature, fix, docs, test, or chore)
- [ ] This PR is in scope for the current roadmap phase (`docs/phases/PHASE1.md`)

## Checklist
- [ ] PR title follows Conventional Commits format (`type(scope): short description`)
- [ ] `make lint` passes
- [ ] `make test` passes with no new failures
- [ ] `make build` compiles cleanly
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] New public functions have Go doc comments
- [ ] Docs updated (if applicable)
- [ ] CRD/API docs updated in `docs/reference/` when changing `api/v1alpha1/`

## Risk and rollout
<!-- Any risk, migration notes, or rollout considerations -->

## Breaking changes
- [ ] No breaking changes
- [ ] Yes (describe below)

## Related issue
Fixes #<issue>

## Notes for reviewers
<!-- Anything you want reviewers to focus on -->
